### PR TITLE
Fixes for ops-pod script

### DIFF
--- a/hacks/ops-pod
+++ b/hacks/ops-pod
@@ -114,7 +114,7 @@ spec:
     effect: NoSchedule
   containers:
   - name: ops-pod
-    image: eu.gcr.io/gardener-project/gardener/ops-toolbelt:latest
+    image: ${image}
     imagePullPolicy: Always
     command:
     - sleep
@@ -140,15 +140,21 @@ spec:
   hostNetwork: true
   hostPID: true
   restartPolicy: Never
-EOF)
+EOF
+)
 while [[ $(kubectl -n $namespace get pods | sed -n -r "s/^$name.*Running.*$/Running/p") != "Running" ]]; do echo "Waiting for pod to be running..."; sleep 1; done;
 
 # exec into pod (and chroot into node if a node was selected)
-if [[ ! -z $node ]]; then
-  kubectl -n $namespace exec -ti $name -- bash -c "rm -rf /host/root/dotfiles 1> /dev/null; cp -r /root/dotfiles /host/root 1> /dev/null; cp -r /guide /host 1> /dev/null; cp -r /hacks /host 1> /dev/null; rm -f /host/root/.bashrc; ln -s /root/dotfiles/.bashrc /host/root/.bashrc 1> /dev/null; export PATH=\"/hacks:$PATH\"; chroot /host /bin/bash"
+if [[ -n $node ]]; then
+  kubectl -n $namespace exec -ti $name -- bash -c "rm -rf /host/root/dotfiles 1> /dev/null; \
+                                                   echo 'cat /root/motd' >> /root/dotfiles/.bashrc; \
+                                                   cp -r /root/dotfiles /host/root 1> /dev/null; \
+                                                   cp -r /hacks /host 1> /dev/null; rm -f /host/root/.bashrc; \
+                                                   cp /etc/motd /host/root/motd; \
+                                                   ln -s /root/dotfiles/.bashrc /host/root/.bashrc 1> /dev/null; export PATH=\"/hacks:$PATH\"; chroot /host /bin/bash"
 else
   kubectl -n $namespace exec -ti $name -- bash
 fi
 
 # get rid of pod
-kubectl -n $namespace delete pod $name &> /dev/null || true
+kubectl -n $namespace delete pod $name &> /dev/null


### PR DESCRIPTION
**What this PR does / why we need it**:
- Removes a copy of missing /guide folder
- Fixes selection of image from `--image` flag
- Properly adds motd

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
motd is properly displayed when starting the toolbelt from the ops-pod script.
```
```improvement operator
--image flag can now be properly used to select the toolbelt image
```