### PR TITLE
Only tag on release as `latest`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -13,7 +13,6 @@ ops-toolbelt:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-gardenctl'
             dockerfile: ops-toolbelt-gardenctl.dockerfile
-            tag_as_latest: True
             inputs:
               steps:
                 build: ~
@@ -21,7 +20,6 @@ ops-toolbelt:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt'
             dockerfile: ops-toolbelt.dockerfile
-            tag_as_latest: True
             inputs:
               steps:
                 build: ~
@@ -43,3 +41,9 @@ ops-toolbelt:
           preprocess: 'finalize'
         release:
           nextversion: 'bump_minor'
+        publish:
+          dockerimages:
+            ops-toolbelt-gardenctl:
+              tag_as_latest: true
+            ops-toolbelt:
+              tag_as_latest: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, on every image publish the latest tag will be set (e.g. also for pull requests). Instead, only tag as latest when releasing.

**Which issue(s) this PR fixes**:
Fixes #5

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
