### PR TITLE
Add tools downloaded with git to ghelp info

### DIFF
--- a/generator/lib/commands.py
+++ b/generator/lib/commands.py
@@ -145,7 +145,7 @@ class InfoGenerator:
                 apt_get_commands.extend(InfoGenerator._get_package_name_and_bins(command))
             if isinstance(command, Pip):
                 pip_commands.extend(InfoGenerator._get_package_name_and_bins(command))
-            if isinstance(command,Curl):
+            if isinstance(command, (Curl, Git)):
                 command_tools = command.get_tools()
                 for tool in command_tools:
                     if tool.get_info() is not None:


### PR DESCRIPTION
**What this PR does / why we need it**:
`ghelp` also reports information regarding tools downloaded from git

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
`ghelp` reports information about tools downloaded with git.
```
