### PR TITLE
Fixes kubectl not being able to be executed

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -46,7 +46,6 @@
   - name: kubectl
     version: v1.17.1
     from: https://storage.googleapis.com/kubernetes-release/release/{version}/bin/linux/amd64/kubectl
-    to: /bin/kubectl
     info: command line tool for controlling Kubernetes clusters
   - name: pip
     from: https://bootstrap.pypa.io/get-pip.py

--- a/generator/lib/commands.py
+++ b/generator/lib/commands.py
@@ -60,7 +60,7 @@ class Curl(Command):
             else:
                 line = "curl -sLf {} -o /bin/{} && chmod 755 /bin/{}".format(tool.get_from(), tool.get_name(), tool.get_name())
             if tool.get_command() is not None:
-                line = line + ";\\\n{}".format(tool.get_command().rstrip())
+                line = line + "; {}".format(tool.get_command().rstrip())
             yield line
 
 class Execute(Command):


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr makes `kubectl` executable again

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fixes `Permission denied` error when trying to execute `kubectl`
```
