### PR TITLE
Adds slack notifications on release

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -41,6 +41,12 @@ ops-toolbelt:
           preprocess: 'finalize'
         release:
           nextversion: 'bump_minor'
+        slack:
+          default_channel: 'internal_scp_workspace'
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: 'k8s-gardener'
+              slack_cfg_name: 'scp_workspace'
         publish:
           dockerimages:
             ops-toolbelt-gardenctl:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds notification to the k8s-gardener slack channel on successful release. Useful since the ops-toolbelt is used for the dashboard WebTerminals

**Which issue(s) this PR fixes**:
Fixes # None

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Adds slack notification on successful release.
```
