### PR TITLE
Per default install latest version of k9s

### DIFF
--- a/hacks/ghelp
+++ b/hacks/ghelp
@@ -61,7 +61,7 @@ def retrieve_downloaded_tools_info(downloaded_tools):
 
 def retrieve_hacks_info():
     tools = [
-        ("install_k9s", "", "Install k9s: curses based terminal UI to interact with your Kubernetes clusters."),
+        ("install_k9s", "LATEST", "Install k9s: curses based terminal UI to interact with your Kubernetes clusters."),
         ("ops-pod", "", "Start an ops-toolbelt container in a k8s cluster")
     ]
 

--- a/hacks/install_k9s
+++ b/hacks/install_k9s
@@ -13,19 +13,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DEFAULT_K9S_VERSION=0.9.3
-
 function show_help () {
   echo "Usage: ${0} [arguments]"
   echo "Possible arguments:"
-  echo "-h, --help       show this help message and exit"
-  echo "-v, --version    Optional: specify k9s version to use"
+  echo "-h, --help       Show this help message and exit"
+  echo "-v, --version    Optional: specify k9s version to use. Default: latest version will be installed"
 }
 
 function install () {
   local version=$1
-  echo "installing k9s version ${version}"
-  curl -sL https://github.com/derailed/k9s/releases/download/${version}/k9s_${version}_Linux_x86_64.tar.gz -o k9s.tar.gz && tar -zxvf k9s.tar.gz k9s && mv k9s /usr/local/bin/k9s && chmod 755 /usr/local/bin/k9s && rm k9s.tar.gz
+  local download_url
+
+  if [ -z "$version" ]
+  then # fetch latest
+    local latest_release=$(curl -sL https://api.github.com/repos/derailed/k9s/releases/latest)
+    version=$(echo "${latest_release}" | jq -r '.tag_name')
+    echo "installing latest version ${version}"
+    download_url=$(echo "${latest_release}" | jq -r '.assets[] | select(.name == "k9s_Linux_x86_64.tar.gz") | .browser_download_url')
+  else
+    if [[ ! $version == v* ]]
+    then
+      version="v${version}"
+    fi
+    echo "installing k9s version ${version}"
+    download_url="https://github.com/derailed/k9s/releases/download/${version}/k9s_Linux_x86_64.tar.gz"
+  fi
+
+  curl -sL ${download_url} -o k9s.tar.gz && tar -zxvf k9s.tar.gz k9s && mv k9s /usr/local/bin/k9s && chmod 755 /usr/local/bin/k9s && rm k9s.tar.gz
+
   echo "You can now start using k9s. Just execute \"k9s\" to use it or \"k9s -n mynamespace\" to target a namespace. See https://github.com/derailed/k9s for more details."
 }
 
@@ -39,7 +54,7 @@ case "$1" in
     exit
     ;;
   *)
-    install "$DEFAULT_K9S_VERSION"
+    install
     exit
     ;;
 esac


### PR DESCRIPTION
**What this PR does / why we need it**:
Improved the install_k9s script so that it installs the latest release of k9s per default.

Also, when specifying the version argument, the v prefix will be added if the version does not already contain it. So you can call it either with `install_k9s -v 0.17.1` or `install_k9s -v v0.17.1` 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
`install_k9s` script will now fetch the latest released version of `k9s` and install it. You can also install an older version with `-v` or `--version` argument as usual.
```
