### PR TITLE
add krew and ketall for kubectl in ops-toolbelt image

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -46,7 +46,7 @@
   - name: kubectl
     version: v1.17.1
     from: https://storage.googleapis.com/kubernetes-release/release/{version}/bin/linux/amd64/kubectl
-    info: command line tool for controlling Kubernetes clusters
+    info: command line tool for controlling Kubernetes clusters. "kubectl krew install plunin_name" to install plugin. "kubectl get-all -n namespace" to list all resources in namespaces.
   - name: pip
     from: https://bootstrap.pypa.io/get-pip.py
     to: /get-pip.py
@@ -109,6 +109,23 @@
     command: |
       echo "export PATH=/hacks:\$PATH" >> /root/.bashrc
     info: ~
+  - name: krew
+    command: |
+      set -x; cd "$(mktemp -d)";\
+      curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/krew.{tar.gz,yaml}";\
+      tar zxvf krew.tar.gz;\
+      KREW=./krew-"$(uname | tr '[:upper:]' '[:lower:]')_amd64";\
+      "$KREW" install --manifest=krew.yaml --archive=krew.tar.gz;\
+      "$KREW" update;\
+      export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH";\
+      echo "export PATH=~/.krew/bin:\$PATH" >>/root/.bashrc
+    info: |
+      krew is plugin manager for kubectl, see https://github.com/kubernetes-sigs/krew
+  - name: ketall
+    command: |
+      kubectl krew install get-all
+    info: |
+      ketall is to enable `kubectl get-all -n namespace_name`, for listing all resources in some namespace
 
 
 - env:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is to add plugin manager (krew) for for kubectl and install the plugin (ketall) to kubectl in the ops-toolbelt image.
After this PR you may use krew and ketall like these
`kubectl plugin list` 
`kubectl  krew list`
`kubectl get-all` <- to get all resource in some namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

for more information please refer to:
https://github.com/kubernetes-sigs/krew
https://github.com/corneliusweig/ketall

tested locally like this (after `docker build` and `docker run`)
![image](https://user-images.githubusercontent.com/42594392/75736814-25fbcf00-5d39-11ea-9e84-dd477759be36.png)

**Release note**:
```improvement user
`krew` is now available so that you can easily add additional `kubectl` plugins with `kubectl krew install {plugin_name}`
``` 
```improvement user
`kubectl` plugin `ketall` is now available. Run `kubectl get-all` to show really all kubernetes resources
```