### PR TITLE
upgrade gardenctl to v0.16.0

### DIFF
--- a/dockerfile-configs/gardenctl-components.yaml
+++ b/dockerfile-configs/gardenctl-components.yaml
@@ -19,7 +19,7 @@
 
 - curl:
   - name: gardenctl
-    version: v0.15.0
+    version: v0.16.0
     from: https://github.com/gardener/gardenctl/releases/download/{version}/gardenctl-linux-amd64
     to: /opt/gardenctl/bin/gardenctl
     command: |


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrade gardenctl to v0.16.0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```improvement user
Upgrade `gardenctl` to latest version `v0.16.0`
```
