### PR TITLE
add ping utility

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -27,6 +27,7 @@
   - jq
   - figlet
   - tcpdump
+  - iputils-ping
   - name: silversearcher-ag
     provides: ag
   - name: iproute2


### PR DESCRIPTION
**What this PR does / why we need it**:
add ping utility in docker image
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/ops-toolbelt/issues/24

**Special notes for your reviewer**:

**Release note**:
```improvement operator
Ping utility is now available in image
```
