### PR TITLE
Clean azure-cli python cache files

### DIFF
--- a/dockerfile-configs/iaas-components.yaml
+++ b/dockerfile-configs/iaas-components.yaml
@@ -27,6 +27,11 @@
   - name: google-cloud-sdk
     provides: gcloud
 
+- bash:
+  - name: clean_azure-cli_pycache
+    command: py3clean -p azure-cli
+    info: ~
+
 - pip:
   - python-novaclient
   - python-glanceclient


### PR DESCRIPTION
**What this PR does / why we need it**:
ClamAV detects`/opt/az/lib/python3.6/test/test_email/_pycache_/test_email.cpython-36.opt-1.pycCleans` as an email, which causes the scan to timeout. This PR adds a clean-up step which will remove all azure-cli python cache files and make ClamAV happy.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Cleans the python cache files of the azure-cli package. This makes the ClamAV email scan happy.
```
