### PR TITLE
Fix GitHub URL in .bash_aliases

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -369,7 +369,7 @@ function clone() {
   else
     owner="$1"
     repo="$2"
-    git clone -c http.sslVerify=false --recursive https://github.wdf.sap.corp/$owner/$repo.git
+    git clone -c http.sslVerify=false --recursive https://github.com/$owner/$repo.git
   fi
 }
 function commit() {


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a wrong Github URL in .bash_aliases. The previous GitHub-URL was pointing to a corporate GitHub instance, which is not accessible through the general internet.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
