### PR TITLE
upgrade gardenctl version to 0.20.0

### DIFF
--- a/dockerfile-configs/gardenctl-components.yaml
+++ b/dockerfile-configs/gardenctl-components.yaml
@@ -19,7 +19,7 @@
 
 - curl:
   - name: gardenctl
-    version: v0.19.0
+    version: v0.20.0
     from: https://github.com/gardener/gardenctl/releases/download/{version}/gardenctl-linux-amd64
     to: /opt/gardenctl/bin/gardenctl
     command: |


### PR DESCRIPTION
**What this PR does / why we need it**:
upgrade gardenctl version to 0.20.0
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
upgrade gardenctl version to 0.20.0
```
