### PR TITLE
upgrade gardenctl version to 0.21.0

### DIFF
--- a/dockerfile-configs/gardenctl-components.yaml
+++ b/dockerfile-configs/gardenctl-components.yaml
@@ -19,7 +19,7 @@
 
 - curl:
   - name: gardenctl
-    version: v0.19.0
+    version: v0.21.0
     from: https://github.com/gardener/gardenctl/releases/download/{version}/gardenctl-linux-amd64
     to: /opt/gardenctl/bin/gardenctl
     command: |


### PR DESCRIPTION
**What this PR does / why we need it**:
upgrade gardenctl version to 0.21.0
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
