### PR TITLE
add github action to receive auto update from gardenctl

### DIFF
--- a/.github/workflows/update-gardenctl.sh
+++ b/.github/workflows/update-gardenctl.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+tag=${1}
+if [ -z "${1}" ]
+then
+      echo "release tag is not provided"
+      exit 1
+fi
+
+echo $tag
+
+cat > dockerfile-configs/gardenctl-components.yaml << EOF
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- bash:
+  - name: make-gardenctl-dir
+    command: mkdir -p /opt/gardenctl/bin
+    info: ~
+
+- curl:
+  - name: gardenctl
+    version: "$tag"
+    from: https://github.com/gardener/gardenctl/releases/download/{version}/gardenctl-linux-amd64
+    to: /opt/gardenctl/bin/gardenctl
+    command: |
+      chmod 755 /opt/gardenctl/bin/gardenctl && \
+      ln -s /opt/gardenctl/bin/gardenctl /usr/local/bin/gardenctl && \
+      mkdir $HOME/.garden && \
+      echo "source <(gardenctl completion bash | grep -v 'Please provide a gardenctl configuration before usage')" >> /root/.bashrc
+    info: command-line client for administrative purposes for Gardener
+
+EOF

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -1,0 +1,22 @@
+name: Remote Dispatch Action
+on: [repository_dispatch]
+jobs:
+  update-gardenctl:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Event Information
+        run: |
+          echo "Event '${{ github.event.action }}' payload '${{ github.event.client_payload.tag }}'"
+      - uses: actions/checkout@v2.1.1
+      - name: Run update script
+        run:  ./.github/workflows/update-gardenctl.sh ${{ github.event.client_payload.tag }}
+      - name: Commit files
+        run: |
+          git config --local user.email "gardener.ci.user@gmail.com"
+          git config --local user.name "gardener-robot-ci-1"
+          git commit -m "Update gardenctl" -a
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.ACCESS_TOKEN }}
+          force: false


### PR DESCRIPTION
**What this PR does / why we need it**:
when a new version of gardenctl is released, the gardenctl version in this repo is also updated automatically
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```improvement operator
when a new version of gardenctl is released, the gardenctl version in this repo is also updated automatically
```
