### PR TITLE
upgrade gardenctl version v0.23.0

### DIFF
--- a/dockerfile-configs/gardenctl-components.yaml
+++ b/dockerfile-configs/gardenctl-components.yaml
@@ -19,7 +19,7 @@
 
 - curl:
   - name: gardenctl
-    version: v0.21.0
+    version: v0.22.0
     from: https://github.com/gardener/gardenctl/releases/download/{version}/gardenctl-linux-amd64
     to: /opt/gardenctl/bin/gardenctl
     command: |

--- a/dockerfile-configs/gardenctl-components.yaml
+++ b/dockerfile-configs/gardenctl-components.yaml
@@ -19,7 +19,7 @@
 
 - curl:
   - name: gardenctl
-    version: v0.22.0
+    version: v0.23.0
     from: https://github.com/gardener/gardenctl/releases/download/{version}/gardenctl-linux-amd64
     to: /opt/gardenctl/bin/gardenctl
     command: |


### PR DESCRIPTION
**What this PR does / why we need it**:
upgrade gardenctl version v0.22.0
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
we are working on the automation in https://github.com/gardener/ops-toolbelt/pull/35 but for this release still we needs manually updated the gardenctl version
**Release note**:
```improvement operator
upgrade gardenctl version v0.23.0
```
