### PR TITLE
Adds iptables-save and wireguard

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -95,15 +95,21 @@
       echo "" >> /root/.bashrc;\
       echo "source /etc/profile.d/bash_completion.sh" >> /root/.bashrc
     info: ~
+  - name: table
+    command: |
+      echo "source /root/dotfiles/.install_on_demand/.table" >> /root/dotfiles/.bashrc
+    info: Helpful tool that can be used to simplify the analysis of iptables entries. Pass a string argument to filter the output via grep.
+  - name: wg
+    command : |
+      echo "source /root/dotfiles/.install_on_demand/.wireguard" >> /root/dotfiles/.bashrc
+    info: Command line tool for the wireguard VPN.
   - name: dotfiles
     command: |
       echo "" >> /root/.bashrc;\
       echo "# source bashrc from dotfiles" >> /root/.bashrc;\
       echo "source /root/dotfiles/.bashrc" >> /root/.bashrc;\
       touch /root/dotfiles/.config/git/config_personal
-    info: |
-      The sourced dotfiles are located under /root/dotfiles.\n\
-      Additionally you can add your own personal git settings in /root/dotfiles/.config/git/config_personal\n\
+    info: Directory containing the currently active (sourced) dotfiles.
   - name: hacks
     command: |
       echo "export PATH=/hacks:\$PATH" >> /root/.bashrc
@@ -112,6 +118,3 @@
 - env:
   - DOTFILES_USER=root
   - DOTFILES_HOME=/root/dotfiles
-
-
-

--- a/dotfiles/.install_on_demand/.table
+++ b/dotfiles/.install_on_demand/.table
@@ -1,0 +1,26 @@
+function table () {
+  if ! hash iptables-save &> /dev/null; then
+    local yes="Yy"
+    local no="Nn"
+    local _confirmation=""
+    while [[ ! $_confirmation =~ ^[$yes$no]$ ]]; do
+          read -p "Required iptables-save not found. Do you want to install it now? (Y/n) " -r _confirmation
+          if [[ $_confirmation =~ ^[$no]$ ]]; then
+            echo -e "Error: iptables-save not installed."
+            return 1
+          fi
+    done
+    echo iptables-persistent iptables-persistent/autosave_v4 boolean true | debconf-set-selections ;\
+    echo iptables-persistent iptables-persistent/autosave_v6 boolean true | debconf-set-selections ;\
+    read -p "Version [latest]: " -r version
+    apt install iptables-persistent"${version:+=$version}" --yes
+  fi
+
+  iptables-save | while IFS= read -r line; do
+    if [ "${line#\**}" != "$line" ]; then
+      table="$line"
+    else
+      echo "$table: $line"
+    fi
+  done | if [ "$#" -gt 0 ]; then grep "$@"; else grep ""; fi
+}

--- a/dotfiles/.install_on_demand/.wireguard
+++ b/dotfiles/.install_on_demand/.wireguard
@@ -1,0 +1,19 @@
+alias wg='wireguard'
+function wireguard() {
+  yes="Yy"
+  no="Nn"
+
+  if ! hash wg &> /dev/null; then
+    local _confirmation=""
+    while [[ ! $_confirmation =~ ^[$yes$no]$ ]]; do
+          read -p "Wireguard not found. Do you want to install it now? (Y/n) " -r _confirmation
+          if [[ $_confirmation =~ ^[$no]$ ]]; then
+            echo -e "Error: wireguard not installed."
+            return 1
+          fi
+    done
+    read -p "Version [latest]: " -r version
+    apt install wireguard"${version:+=$version}" --yes
+  fi
+  command wg "$@"
+}

--- a/generator/lib/commands.py
+++ b/generator/lib/commands.py
@@ -145,7 +145,7 @@ class InfoGenerator:
                 apt_get_commands.extend(InfoGenerator._get_package_name_and_bins(command))
             if isinstance(command, Pip):
                 pip_commands.extend(InfoGenerator._get_package_name_and_bins(command))
-            if isinstance(command, (Curl, Git)):
+            if isinstance(command, (Curl, Git, Execute)):
                 command_tools = command.get_tools()
                 for tool in command_tools:
                     if tool.get_info() is not None:

--- a/generator/lib/components.py
+++ b/generator/lib/components.py
@@ -97,12 +97,21 @@ class BashCommandConfig(DictComponentConfig):
     required_keys = [
         {"key": "command", "types": (str)}
     ]
+
+    optional_keys = [
+        {"key": "version", "types": (str)},
+    ]
+
     def __init__(self, config):
         DictComponentConfig.__init__(self, config)
         self.command = config["command"]
+        self.version = config.get("version")
 
     def get_command(self):
         return self.command
+
+    def get_version(self):
+        return self.version
 
 class AptRepoConfig(DictComponentConfig):
     required_keys = [


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the proposed `table` command from #46 and wireguard. 
These are not directly installed in the container during build time but will be downloaded only if necessary.

**Which issue(s) this PR fixes**:
Fixes #46 

**Special notes for your reviewer**:
@neo-liang-sap as discussed in slack, I am opening this PR in place of #47 so we can close that one.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Added the `table` command which uses `iptables-save` to list helpful info about iptable entries. 
```
```improvement operator
Added the `wg` command which can be used when debugging the WireGuard VPN.
```
