### PR TITLE
Revert to k9s old style binary names

### DIFF
--- a/hacks/install_k9s
+++ b/hacks/install_k9s
@@ -29,14 +29,14 @@ function install () {
     local latest_release=$(curl -sL https://api.github.com/repos/derailed/k9s/releases/latest)
     version=$(echo "${latest_release}" | jq -r '.tag_name')
     echo "installing latest version ${version}"
-    download_url=$(echo "${latest_release}" | jq -r '.assets[] | select(.name == "k9s_'"${version}"'_Linux_x86_64.tar.gz") | .browser_download_url')
+    download_url=$(echo "${latest_release}" | jq -r '.assets[] | select(.name == "k9s_Linux_x86_64.tar.gz") | .browser_download_url')
   else
     if [[ ! $version == v* ]]
     then
       version="v${version}"
     fi
     echo "installing k9s version ${version}"
-    download_url="https://github.com/derailed/k9s/releases/download/${version}/k9s_${version}_Linux_x86_64.tar.gz"
+    download_url="https://github.com/derailed/k9s/releases/download/${version}/k9s_Linux_x86_64.tar.gz"
   fi
 
   curl -sL ${download_url} -o k9s.tar.gz && tar -zxvf k9s.tar.gz k9s && mv k9s /usr/local/bin/k9s && chmod 755 /usr/local/bin/k9s && rm k9s.tar.gz


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reverts the change introduced with #51 as with the latest `k9s` release https://github.com/derailed/k9s/releases/tag/v0.24.11 it was decided
>[...] to revert the old style binaries names as this disrupted all the release upstream

See also https://github.com/derailed/k9s/issues/1131

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
