### PR TITLE
Remove dots from names of docker image definitions

### DIFF
--- a/.ci/build_pipeline_definitions
+++ b/.ci/build_pipeline_definitions
@@ -36,11 +36,11 @@ EOF
 
 for kv_short in `cat "${SOURCE_PATH}"/.ci/k8s_versions |cut -d '.' -f 1,2`
 do
+    kv_underscore=$(echo "${kv_short}" | tr '.' '_')
     for iaas_provider in `cat "${SOURCE_PATH}"/.ci/iaas_providers`
     do
-
       cat >> "${SOURCE_PATH}"/.ci/pipeline_definitions << EOF
-          ops-toolbelt-$iaas_provider-k$kv_short:
+          ops-toolbelt-$iaas_provider-k$kv_underscore:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-$iaas_provider-k$kv_short'
             dockerfile: ops-toolbelt-$iaas_provider-k$kv_short.dockerfile

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,140 +23,140 @@ ops-toolbelt:
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-aws-k1.20:
+          ops-toolbelt-aws-k1_20:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-aws-k1.20'
             dockerfile: ops-toolbelt-aws-k1.20.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-az-k1.20:
+          ops-toolbelt-az-k1_20:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-az-k1.20'
             dockerfile: ops-toolbelt-az-k1.20.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-gcp-k1.20:
+          ops-toolbelt-gcp-k1_20:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-gcp-k1.20'
             dockerfile: ops-toolbelt-gcp-k1.20.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-openstack-k1.20:
+          ops-toolbelt-openstack-k1_20:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-openstack-k1.20'
             dockerfile: ops-toolbelt-openstack-k1.20.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-aliyun-k1.20:
+          ops-toolbelt-aliyun-k1_20:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-aliyun-k1.20'
             dockerfile: ops-toolbelt-aliyun-k1.20.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-aws-k1.19:
+          ops-toolbelt-aws-k1_19:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-aws-k1.19'
             dockerfile: ops-toolbelt-aws-k1.19.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-az-k1.19:
+          ops-toolbelt-az-k1_19:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-az-k1.19'
             dockerfile: ops-toolbelt-az-k1.19.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-gcp-k1.19:
+          ops-toolbelt-gcp-k1_19:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-gcp-k1.19'
             dockerfile: ops-toolbelt-gcp-k1.19.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-openstack-k1.19:
+          ops-toolbelt-openstack-k1_19:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-openstack-k1.19'
             dockerfile: ops-toolbelt-openstack-k1.19.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-aliyun-k1.19:
+          ops-toolbelt-aliyun-k1_19:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-aliyun-k1.19'
             dockerfile: ops-toolbelt-aliyun-k1.19.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-aws-k1.18:
+          ops-toolbelt-aws-k1_18:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-aws-k1.18'
             dockerfile: ops-toolbelt-aws-k1.18.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-az-k1.18:
+          ops-toolbelt-az-k1_18:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-az-k1.18'
             dockerfile: ops-toolbelt-az-k1.18.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-gcp-k1.18:
+          ops-toolbelt-gcp-k1_18:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-gcp-k1.18'
             dockerfile: ops-toolbelt-gcp-k1.18.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-openstack-k1.18:
+          ops-toolbelt-openstack-k1_18:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-openstack-k1.18'
             dockerfile: ops-toolbelt-openstack-k1.18.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-aliyun-k1.18:
+          ops-toolbelt-aliyun-k1_18:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-aliyun-k1.18'
             dockerfile: ops-toolbelt-aliyun-k1.18.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-aws-k1.17:
+          ops-toolbelt-aws-k1_17:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-aws-k1.17'
             dockerfile: ops-toolbelt-aws-k1.17.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-az-k1.17:
+          ops-toolbelt-az-k1_17:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-az-k1.17'
             dockerfile: ops-toolbelt-az-k1.17.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-gcp-k1.17:
+          ops-toolbelt-gcp-k1_17:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-gcp-k1.17'
             dockerfile: ops-toolbelt-gcp-k1.17.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-openstack-k1.17:
+          ops-toolbelt-openstack-k1_17:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-openstack-k1.17'
             dockerfile: ops-toolbelt-openstack-k1.17.dockerfile
             inputs:
               steps:
                 build: ~
-          ops-toolbelt-aliyun-k1.17:
+          ops-toolbelt-aliyun-k1_17:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt-aliyun-k1.17'
             dockerfile: ops-toolbelt-aliyun-k1.17.dockerfile


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the names of the docker image definitions in the pipeline_definitions so that they can be properly handled by or ci/cd

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
