### PR TITLE
fix(ops-pod): sanitize host/pod names

### DIFF
--- a/hacks/ops-pod
+++ b/hacks/ops-pod
@@ -57,7 +57,12 @@ tolerations_array="
 "
 copy_tolerations=${FALSE}
 node_chroot=${FALSE}
-name="ops-pod-$(whoami)"
+sanitize_hostname() {
+    # K8s rejects pod names that violate this RE '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+    # due to RFC1123 (Only allow lower-case and alphanumerical values for hostnames)
+    echo "$@" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g'
+}
+name="$(sanitize_hostname "ops-pod-$(whoami)")"
 
 default_image="eu.gcr.io/gardener-project/gardener/ops-toolbelt:latest"
 function get_default_namespace() {


### PR DESCRIPTION
Signed-off-by: Max Falk <gmdfalk@gmail.com>

**What this PR does / why we need it**:
It fixes an issue in the ops-pod script where invalid pod names can be created based on the value of `whoami` leading to k8s being unable to schedule/create the ops-pod.

Example:
```
./ops-pod shoot--hcm-eng--cls02-logging-z1-6c4fb-g97t5
Node name provided ...
Deploying ops pod on shoot--hcm-eng--cls02-logging-z1-6c4fb-g97t5

The Pod "ops-pod-I522542" is invalid: metadata.name: Invalid value: "ops-pod-I522542": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
Error from server (NotFound): pods "ops-pod-I522542" not found
```

This PR sanitizes the pod name according to RFC 1123 before submitting it to k8s so that it can be scheduled.

**Which issue(s) this PR fixes**:
Fixes an issue where ops-pods cannot be created due to invalid hostname.

**Special notes for your reviewer**:

**Release note**:
```improvement operator
Fixes an issue where ops-pods cannot be created due to invalid hostname.
```
