### PR TITLE
Fix vi alias

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -354,7 +354,7 @@ alias shrink='sips -Z 1024'
 #########
 
 # vi
-alias vi='vim'
+alias vi='vim.tiny'
 
 # grep
 alias grep='grep --color'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the `vi` alias, which pointed to `vim`, however runing `vi` results in the error `bash: vim: command not found`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed `vi` alias
```
