### PR TITLE
Enhance the ops-pod Pod spec

### DIFF
--- a/hacks/ops-pod
+++ b/hacks/ops-pod
@@ -176,6 +176,7 @@ $tolerations_array
     - name: host-root-volume
       mountPath: /host
       readOnly: false
+      mountPropagation: HostToContainer
   volumes:
   - name: host-root-volume
     hostPath:
@@ -183,6 +184,7 @@ $tolerations_array
   hostNetwork: true
   hostPID: true
   restartPolicy: Never
+  enableServiceLinks: false
 EOF
 )
 


### PR DESCRIPTION
/kind enhancement

This PR:
- Adds the option `mountPropagation=HostToContainer` to the volumeMount. Without this option in some environments the ops Pod won't receive information about subsequent mounts on the host. This prevents an operator to debug mount issues on the Node. Ref https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation
- Disables service link. In namespaces with a lot of Services the ops Pod creation can fail without this setting. By default kubelet injects information for all services as env variables to the Pod. Ref https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service

Credits to @dguendisch 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
