### PR TITLE
Fix build - Use corresponding script for python 3.6

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -44,7 +44,7 @@
     from: https://github.com/bronze1man/yaml2json/releases/download/{version}/yaml2json_linux_amd64
     info: transform yaml string to json string without the type infomation.
   - name: pip
-    from: https://bootstrap.pypa.io/get-pip.py
+    from: https://bootstrap.pypa.io/pip/3.6/get-pip.py
     to: /get-pip.py
     command: |
       python3 /get-pip.py;\


### PR DESCRIPTION
**What this PR does / why we need it**:
The build currently fails with: `ERROR: This script does not work on Python 3.6 The minimum supported Python version is 3.7. Please use https://bootstrap.pypa.io/pip/3.6/get-pip.py instead.`

This PR switches to the suggested url.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
