### PR TITLE
Update version of IaaS clients

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -1,5 +1,6 @@
 #!/bin/bash -eu
 
+UBUNTU_VERSION=20.04
 SOURCE_PATH=${SOURCE_PATH:-}
 GENERATED_DOCKERFILES_PATH=${GENERATED_DOCKERFILES_PATH:-}
 
@@ -12,7 +13,7 @@ if [[ -z "${GENERATED_DOCKERFILES_PATH}" ]]; then
     mkdir -p "${GENERATED_DOCKERFILES_PATH}"
 fi
 
-latest_kv=`cat "${SOURCE_PATH}"/.ci/k8s_versions |head -1`
+latest_kv=$(cat "${SOURCE_PATH}"/.ci/k8s_versions |head -1)
 cat > "${SOURCE_PATH}"/dockerfile-configs/kubectl-components.yaml << EOF
     - curl:
       - name: kubectl
@@ -24,7 +25,7 @@ EOF
 "${SOURCE_PATH}"/generator/generate-dockerfile.py \
     --dockerfile-config "${SOURCE_PATH}"/dockerfile-configs/common-components.yaml \
     --dockerfile-configs "${SOURCE_PATH}"/dockerfile-configs/kubectl-components.yaml \
-    --from-image ubuntu:18.04 \
+    --from-image "ubuntu:${UBUNTU_VERSION}" \
     --title "gardener shell" \
     --dockerfile "${GENERATED_DOCKERFILES_PATH}"/ops-toolbelt.dockerfile
 
@@ -33,13 +34,13 @@ EOF
     --dockerfile-configs "${SOURCE_PATH}"/dockerfile-configs/iaas-components.yaml \
     --dockerfile-configs "${SOURCE_PATH}"/dockerfile-configs/gardenctl-components.yaml \
     --dockerfile-configs "${SOURCE_PATH}"/dockerfile-configs/kubectl-components.yaml \
-    --from-image ubuntu:18.04 \
+    --from-image "ubuntu:${UBUNTU_VERSION}" \
     --title "gardener shell" \
     --dockerfile "${GENERATED_DOCKERFILES_PATH}"/ops-toolbelt-gardenctl.dockerfile
 
-for kv in `cat "${SOURCE_PATH}"/.ci/k8s_versions`
+for kv in $(cat "${SOURCE_PATH}"/.ci/k8s_versions)
 do
-    kv_short=`echo $kv |cut -d '.' -f 1,2`
+    kv_short=$(echo $kv |cut -d '.' -f 1,2)
     cat > "${SOURCE_PATH}"/dockerfile-configs/kubectl-components.yaml << EOF
             - curl:
               - name: kubectl
@@ -47,14 +48,14 @@ do
                 from: https://storage.googleapis.com/kubernetes-release/release/v$kv/bin/linux/amd64/kubectl
                 info: command line tool for controlling Kubernetes clusters.
 EOF
-    for iaas_provider in `cat "${SOURCE_PATH}"/.ci/iaas_providers`
+    for iaas_provider in $(cat "${SOURCE_PATH}"/.ci/iaas_providers)
     do
         "${SOURCE_PATH}"/generator/generate-dockerfile.py \
             --dockerfile-configs "${SOURCE_PATH}"/dockerfile-configs/common-components.yaml \
             --dockerfile-configs "${SOURCE_PATH}"/dockerfile-configs/$iaas_provider-components.yaml \
             --dockerfile-configs "${SOURCE_PATH}"/dockerfile-configs/gardenctl-components.yaml \
             --dockerfile-configs "${SOURCE_PATH}"/dockerfile-configs/kubectl-components.yaml \
-            --from-image ubuntu:18.04 \
+            --from-image "ubuntu:${UBUNTU_VERSION}" \
             --title "gardener shell" \
             --dockerfile "${GENERATED_DOCKERFILES_PATH}"/ops-toolbelt-$iaas_provider-k$kv_short.dockerfile
 

--- a/dockerfile-configs/aliyun-components.yaml
+++ b/dockerfile-configs/aliyun-components.yaml
@@ -19,7 +19,7 @@
 
 - curl:
   - name: aliyun
-    version: 3.0.73
+    version: 3.0.117
     from: https://github.com/aliyun/aliyun-cli/releases/download/v{version}/aliyun-cli-linux-{version}-amd64.tgz
     to: /aliyun-cli-linux-amd64.tgz
     command: |

--- a/dockerfile-configs/aws-components.yaml
+++ b/dockerfile-configs/aws-components.yaml
@@ -18,5 +18,5 @@
     info: ~
 
 - pip:
-  - name: awscli==1.18.133
+  - name: awscli==1.23.6
     provides: aws

--- a/dockerfile-configs/az-components.yaml
+++ b/dockerfile-configs/az-components.yaml
@@ -23,7 +23,7 @@
     info: ~
 
 - apt-get:
-  - name: azure-cli=2.11.1-1~bionic
+  - name: azure-cli=2.36.0-1~bionic
     provides: az
 
 - bash:

--- a/dockerfile-configs/gcp-components.yaml
+++ b/dockerfile-configs/gcp-components.yaml
@@ -24,5 +24,5 @@
     info: ~
 
 - apt-get:
-  - name: google-cloud-sdk=329.0.0-0
+  - name: google-cloud-sdk=384.0.1-0
     provides: gcloud

--- a/dockerfile-configs/iaas-components.yaml
+++ b/dockerfile-configs/iaas-components.yaml
@@ -27,9 +27,9 @@
     info: ~
 
 - apt-get:
-  - name: azure-cli=2.11.1-1~bionic
+  - name: azure-cli=2.36.0-1~bionic
     provides: az
-  - name: google-cloud-sdk=329.0.0-0
+  - name: google-cloud-sdk=384.0.0-0
     provides: gcloud
 
 - bash:
@@ -38,18 +38,18 @@
     info: ~
 
 - pip:
-  - python-novaclient==17.2.0
-  - python-glanceclient==3.2.1
-  - python-cinderclient==7.1.0
-  - python-swiftclient==3.10.0
-  - name: python-openstackclient==5.3.1
+  - python-novaclient==17.7.0
+  - python-glanceclient==3.6.0
+  - python-cinderclient==8.3.0
+  - python-swiftclient==3.13.1
+  - name: python-openstackclient==5.8.0
     provides: ["openstack", "openstack-inventory"]
-  - name: awscli==1.18.133
+  - name: awscli==1.23.6
     provides: aws
 
 - curl:
   - name: aliyun
-    version: 3.0.73
+    version: 3.0.117
     from: https://github.com/aliyun/aliyun-cli/releases/download/v{version}/aliyun-cli-linux-{version}-amd64.tgz
     to: /aliyun-cli-linux-amd64.tgz
     command: |

--- a/dockerfile-configs/openstack-components.yaml
+++ b/dockerfile-configs/openstack-components.yaml
@@ -18,9 +18,9 @@
     info: ~
 
 - pip:
-  - python-novaclient==17.2.0
-  - python-glanceclient==3.2.1
-  - python-cinderclient==7.1.0
-  - python-swiftclient==3.10.0
-  - name: python-openstackclient==5.3.1
+  - python-novaclient==17.7.0
+  - python-glanceclient==3.6.0
+  - python-cinderclient==8.3.0
+  - python-swiftclient==3.13.1
+  - name: python-openstackclient==5.8.0
     provides: ["openstack", "openstack-inventory"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates versions of aws, aliyun, azure, openstack, gcp and the base ubuntu image.

 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@petersutter I wonder if we should also update the ubuntu image to 20.04?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updated versions of IaaS clients:
- aws client update to 1.23.6
- aliyun client updated to 3.0.117
- azure client updated to 2.36.0
- google cloud sdk updated to 384.0.1
- python-novaclient updated to 17.7.0
- python-glanceclient updated to 3.6.0
- python-cinderclient updated to 8.3.0
- python-swiftclient updated to 3.13.1
- python-openstackclient updated to 5.8.0
```
```other operator
Updated base image to Ubuntu:20.04
```
