### PR TITLE
Fix gcloud and azure-cli installations

### DIFF
--- a/dockerfile-configs/az-components.yaml
+++ b/dockerfile-configs/az-components.yaml
@@ -23,7 +23,7 @@
     info: ~
 
 - apt-get:
-  - name: azure-cli=2.36.0-1~bionic
+  - name: azure-cli=2.36.0-1~focal
     provides: az
 
 - bash:

--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -44,7 +44,7 @@
     from: https://github.com/bronze1man/yaml2json/releases/download/{version}/yaml2json_linux_amd64
     info: transform yaml string to json string without the type infomation.
   - name: pip
-    from: https://bootstrap.pypa.io/pip/3.6/get-pip.py
+    from: https://bootstrap.pypa.io/pip/get-pip.py
     to: /get-pip.py
     command: |
       python3 /get-pip.py;\
@@ -64,7 +64,7 @@
     from: https://raw.githubusercontent.com/johanhaleby/kubetail/master/kubetail
     info: Bash script that enables you to aggregate (tail/follow) logs from multiple pods into one stream
   - name: nerdctl
-    version: 0.10.0
+    version: 0.19.0
     from: https://github.com/containerd/nerdctl/releases/download/v{version}/nerdctl-{version}-linux-amd64.tar.gz
     to: /nerdctl.tar.gz
     command: |

--- a/dockerfile-configs/gcp-components.yaml
+++ b/dockerfile-configs/gcp-components.yaml
@@ -14,9 +14,10 @@
 
 - add-apt-repo:
   - name: gcp-repo
-    release-prefix: cloud-sdk-
-    url: https://packages.cloud.google.com/apt
+    repo: cloud-sdk
+    url: "[signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt"
     key-url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    keyring: /usr/share/keyrings/cloud.google.gpg
 
 - bash:
   - name: clean_apt

--- a/dockerfile-configs/iaas-components.yaml
+++ b/dockerfile-configs/iaas-components.yaml
@@ -14,9 +14,10 @@
 
 - add-apt-repo:
   - name: gcp-repo
-    release-prefix: cloud-sdk-
-    url: https://packages.cloud.google.com/apt
+    repo: cloud-sdk
+    url: "[signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt"
     key-url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    keyring: /usr/share/keyrings/cloud.google.gpg
   - name: azure-cli
     url: https://packages.microsoft.com/repos/azure-cli
     key-url: https://packages.microsoft.com/keys/microsoft.asc
@@ -27,9 +28,9 @@
     info: ~
 
 - apt-get:
-  - name: azure-cli=2.36.0-1~bionic
+  - name: azure-cli=2.36.0-1~focal
     provides: az
-  - name: google-cloud-sdk=384.0.0-0
+  - name: google-cloud-sdk=384.0.1-0
     provides: gcloud
 
 - bash:

--- a/generator/lib/commands.py
+++ b/generator/lib/commands.py
@@ -102,14 +102,21 @@ class AddAptGetRepo(Command):
         ]
         for component in self.components:
             release_prefix = component.get_release_prefix()
+            repo = component.get_repo()
             repo_name = component.get_name()
             repo_url = component.get_repo_url()
             key_url = component.get_key_url()
+            keyring = component.get_keyring()
+            if repo == "":
+                repo = '"{}$(lsb_release -cs)"'.format(release_prefix)
             download_command = [
-                'REPO="{}$(lsb_release -cs)"'.format(release_prefix),
+                'REPO="{}"'.format(repo),
                 'echo "deb {} $REPO main" | tee /etc/apt/sources.list.d/{}.list'.format(repo_url, repo_name),
-                'curl -sL {} | apt-key add -'.format(key_url),
             ]
+            if keyring == "":
+                download_command.append('curl -sL {} | apt-key add -'.format(key_url))
+            else:
+                download_command.append('curl -sL {} | apt-key --keyring {} add -'.format(key_url, keyring))
             command.extend(download_command)
 
         command.extend([

--- a/generator/lib/components.py
+++ b/generator/lib/components.py
@@ -120,16 +120,26 @@ class AptRepoConfig(DictComponentConfig):
     ]
 
     optional_keys = [
-        {"key": "release-prefix", "types": (str)}
+        {"key": "release-prefix", "types": (str)},
+        {"key": "repo", "types": (str)},
+        {"key": "keyring", "types": (str)}
     ]
     def __init__(self, config):
         DictComponentConfig.__init__(self, config)
         self.release_prefix = config.get("release-prefix", "")
+        self.repo = config.get("repo", "")
+        self.keyring = config.get("keyring", "")
         self.url = config["url"]
         self.key_url = config["key-url"]
 
     def get_release_prefix(self):
         return self.release_prefix
+
+    def get_repo(self):
+        return self.repo
+
+    def get_keyring(self):
+        return self.keyring
 
     def get_repo_url(self):
         return self.url


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the gcloud azure clients installtions that were broken by #69 due to also updating the ubuntu version to 20.04 
Additionally changes back the pip installation to use `https://bootstrap.pypa.io/pip/get-pip.py` as on ubuntu 20.04 python3.8 can be installed (there is no `https://bootstrap.pypa.io/pip/3.8/get-pip.py` so that i can pin the url to the specific python version)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed missing installations of gcloud and azure clients inside IaaS ops-toolbelt images.
```
