### PR TITLE
Fixes ghelp command when there are pinned versions of tools

### DIFF
--- a/dockerfile-configs/openstack-components.yaml
+++ b/dockerfile-configs/openstack-components.yaml
@@ -18,9 +18,13 @@
     info: ~
 
 - pip:
-  - python-novaclient==17.7.0
-  - python-glanceclient==3.6.0
-  - python-cinderclient==8.3.0
-  - python-swiftclient==3.13.1
+  - name: python-novaclient==17.7.0
+    provides: "nova"
+  - name: python-glanceclient==3.6.0
+    provides: "glance"
+  - name: python-cinderclient==8.3.0
+    provides: "cinder"
+  - name: python-swiftclient==3.13.1
+    provides: "swift"
   - name: python-openstackclient==5.8.0
     provides: ["openstack", "openstack-inventory"]

--- a/generator/lib/commands.py
+++ b/generator/lib/commands.py
@@ -27,7 +27,7 @@ class Command:
         return [component for component in self.components]
 
     def get_tool_names(self):
-        return [component.name for component in self.components]
+        return [component.get_name() for component in self.components]
 
     def get_tool_infos(self):
         return [component.get_info() for component in self.components]

--- a/hacks/ghelp
+++ b/hacks/ghelp
@@ -36,13 +36,14 @@ def parse_package_info(package_info, provided_binaries, name_key, version_key, i
             info = line.split(":", 1)[1].strip()
     return [binaries, version, info]
 
-def retrieve_packages_info(installed_tools_list, package_manager, show_command, delimiter, name_key, version_key, info_key):
+def retrieve_packages_info(installed_tools_list, package_manager, show_command, version_delimiter, delimiter, name_key, version_key, info_key):
     tools = []
     provided_binaries = {}
     tool_names = []
     for entry in installed_tools_list:
-        tool_names.append(entry[0])
-        provided_binaries[entry[0]] = entry[1]
+        nameWithoutVersion = entry[0].split(version_delimiter)[0]
+        tool_names.append(nameWithoutVersion)
+        provided_binaries[nameWithoutVersion] = entry[1]
     command = [package_manager, show_command]
     command.extend(tool_names)
     output = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, universal_newlines=True)
@@ -77,8 +78,8 @@ if ghelp_info is None:
     print("Failed to load ghelp info")
     exit(1)
 
-apttools = retrieve_packages_info(ghelp_info["apt"], "apt", "show", "\n\n", "Package", "Version", "Description")
-piptools = retrieve_packages_info(ghelp_info["pip"], "pip", "show", "---", "Name", "Version", "Summary")
+apttools = retrieve_packages_info(ghelp_info["apt"], "apt", "show", "=", "\n\n" , "Package", "Version", "Description")
+piptools = retrieve_packages_info(ghelp_info["pip"], "pip", "show", "==", "---", "Name", "Version", "Summary")
 downloaded_tools = retrieve_downloaded_tools_info(ghelp_info["downloaded"])
 hack_tools = retrieve_hacks_info()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an error that happens when calling `ghelp` if a tool that is install via `apt`  was pinned to a specific version. E.g.  when including `azure-cli=2.36.0-1~focal` in the docker image.

The error that this PR fixes is:
```
$ ghelp
Traceback (most recent call last):
  File "/hacks/ghelp", line 80, in <module>
    apttools = retrieve_packages_info(ghelp_info["apt"], "apt", "show", "\n\n", "Package", "Version", "Description")
  File "/hacks/ghelp", line 51, in retrieve_packages_info
    tool = parse_package_info(tool_info, provided_binaries, name_key, version_key, info_key)
  File "/hacks/ghelp", line 30, in parse_package_info
    binaries = provided_binaries[name]
KeyError: 'azure-cli'
```

Additionally if a tool that is pinned to a specific version and installed via `pip` would previously not appear in the output of `ghelp`. This PR fixes that as well

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed `ghelp` to no longer return errors when some tools that are installed via `apt` or `pip` are pinned to a specific version. 
```
