### PR TITLE
Add sysstat package (e.g. for iostat commands)

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -26,6 +26,7 @@
   - jq
   - figlet
   - tcpdump
+  - sysstat
   - iputils-ping
   - name: silversearcher-ag
     provides: ag


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the `sysstat` package to the list of apt packages.
This contains useful utilities like `iostat`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`sysstat` package is added to the ops-toolbelt containing useful utilities like `iostat`
```
