### PR TITLE
Allow scheduling ops-pod on any node by default

### DIFF
--- a/hacks/ops-pod
+++ b/hacks/ops-pod
@@ -47,13 +47,7 @@ namespace=
 node=
 image=
 tolerations_array="
-  - key: node-role.kubernetes.io/master
-    operator: Exists
-    effect: NoSchedule
   - operator: Exists
-    effect: NoExecute
-  - key: CriticalAddonsOnly
-    operator: Exists
 "
 copy_tolerations=${FALSE}
 node_chroot=${FALSE}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, if any taint is declared on a node, it is not possible to schedule the ops-pod.

I'm proposing to change the default to allow any taint since ops-pod is an ops tool that should give privileged access on any node.

The risk of changing this default is that an ops-pod can block draining of nodes but any operator using the ops-pod should be aware of this.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Allow scheduling ops-pod on any node by default.
```
