### PR TITLE
Add iotop and iftop utilities

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -23,6 +23,8 @@
   - python3-distutils
   - dstat
   - ngrep
+  - iotop
+  - iftop
   - jq
   - figlet
   - tcpdump


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `iotop` and `iftop` utilities.
(Image size grows by a few kilobytes only.)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`iotop` and `iftop` are now installed into the image.
```
