### PR TITLE
Added crictl to work with containerd to the toolbelt

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -76,6 +76,15 @@
     version: v1.22.7
     from: https://storage.googleapis.com/kubernetes-release/release/v1.22.7/bin/linux/amd64/kubectl
     info: command line tool for controlling Kubernetes clusters.
+  - name: crictl
+    version: v1.24.1
+    from: https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.24.1/crictl-v1.24.1-linux-amd64.tar.gz
+    to: /crictl.tar.gz
+    command: |
+      tar zxvf crictl.tar.gz -C /usr/local/bin &&\
+      rm -f crictl.tar.gz &&\
+      echo runtime-endpoint: unix:///host/run/containerd/containerd.sock > /etc/crictl.yaml
+    info: CLI for kubelet CRI.
 
 - bash:
   - name: generate_locale


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `crictl` to the ops toolbelt to help inspect and debug container runtimes and applications on the nodes. 
https://kubernetes.io/docs/tasks/debug/debug-cluster/crictl/ 

It provides an alternative to docker cli and a comparison can be found here -
https://kubernetes.io/docs/reference/tools/map-crictl-dockercli/ 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
ops-toolbelt now supports crictl as a cli to inspect and debug nodes
```
