### PR TITLE
Include `nerdctl` default configs to make it easy to consume

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -70,8 +70,11 @@
     to: /nerdctl.tar.gz
     command: |
       tar Cxzvvf /usr/local/bin nerdctl.tar.gz &&\
-      rm -f nerdctl.tar.gz
-    info: nerdctl is a Docker-compatible CLI for containerd. If the root directory of the host is mounted you can use the files under /hostroot/run/ to connect to the container runtime of the host e.g. 'nerdctl --address unix:///hostroot/run/containerd/contaierd.sock ps'
+      rm -f nerdctl.tar.gz &&\
+      mkdir /etc/nerdctl &&\
+      echo address = \"unix:///host/run/containerd/containerd.sock\" >> /etc/nerdctl/nerdctl.toml &&\
+      echo namespace = \"k8s.io\" >> /etc/nerdctl/nerdctl.toml
+    info: nerdctl is a Docker-compatible CLI for containerd. The root directory of the host has to be mounted under `/host`
   - name: kubectl
     version: v1.22.7
     from: https://storage.googleapis.com/kubernetes-release/release/v1.22.7/bin/linux/amd64/kubectl


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR adds some default configurations required for `nerdctl` to work out of the box for an operator. 

We can also let the operator learn it via going through the docs - https://github.com/containerd/nerdctl/blob/master/docs/config.md 

The PR tries to make it easier as even following the standard docs mentioned above can be a little tricky for ops-pod as was observed in my usage - 
```
root at ip-10-180-17-205.eu-west-1.compute.internal in /
$ nerdctl ps 
FATA[0000] cannot access containerd socket "/run/containerd/containerd.sock": no such file or directory 
```
As for the ops pod the correct path is  `/home/run/containerd/containerd.sock`, having this already captured can be handy for newbies. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is just something which affected me with my limited expertise. However, If you feel this is a one-off case as no one else has mentioned of any struggle with using `nerdctl` and given the the tooling has been in place for sometime now, then please feel free to reject the submission. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Default configs for nerdctl cli are now included in the toolbelt. 
```
