### PR TITLE
Adds command to install security upgrades during build

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -42,6 +42,13 @@
   - name: python3-minimal
     provides: python3
 
+- bash:
+  - name: install-security-upgrades
+    command: |
+      apt-get --yes update && apt-get -s dist-upgrade | grep "^Inst" | grep -i securi | awk -F " " {'print $2'} | xargs apt-get install;\
+      rm -rf /var/lib/apt/lists
+    info: ~
+
 - curl:
   - name: yaml2json
     version: v1.3


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR security upgrades for the Ubuntu base image will be automatically installed during the build of the `ops-toolbelt` image.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Security updates for the Ubuntu base image are now automatically installed during the build of the ops-toolbelt image.
```
