### PR TITLE
add 'netstat' to ops-toolbelt image

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -31,6 +31,7 @@
   - sysstat
   - iputils-ping
   - locales
+  - net-tools
   - name: silversearcher-ag
     provides: ag
   - name: iproute2


### PR DESCRIPTION
**What this PR does / why we need it**:
Helpful in troubleshooting.
Image size did not notably increase
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
