### PR TITLE
Bump kubectl and nerdctl

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -66,7 +66,7 @@
     from: https://raw.githubusercontent.com/johanhaleby/kubetail/master/kubetail
     info: Bash script that enables you to aggregate (tail/follow) logs from multiple pods into one stream
   - name: nerdctl
-    version: 0.22.0
+    version: 1.5.0
     from: https://github.com/containerd/nerdctl/releases/download/v{version}/nerdctl-{version}-linux-amd64.tar.gz
     to: /nerdctl.tar.gz
     command: |
@@ -77,8 +77,8 @@
       echo namespace = \"k8s.io\" >> /etc/nerdctl/nerdctl.toml
     info: nerdctl is a Docker-compatible CLI for containerd. The root directory of the host has to be mounted under `/host`
   - name: kubectl
-    version: v1.24.3
-    from: https://storage.googleapis.com/kubernetes-release/release/v1.24.3/bin/linux/amd64/kubectl
+    version: v1.25.12
+    from: https://dl.k8s.io/release/v1.25.12/bin/linux/amd64/kubectl
     info: command line tool for controlling Kubernetes clusters.
 
 - bash:


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumped cli versions:
- kubectl -> `v1.25.12`
- nerdctl -> `1.5.0`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Bumped cli versions:
- kubectl -> `v1.25.12`
- nerdctl -> `1.5.0`
```
