### PR TITLE
fix default_image

### DIFF
--- a/hacks/ops-pod
+++ b/hacks/ops-pod
@@ -40,7 +40,6 @@ image=
 node_chroot=${NO_CHROOT}
 name="ops-pod-$(whoami)"
 
-default_image="eu.gcr.io/gardener-project/gardener/ops-toolbelt:latest"
 function get_default_namespace() {
   _namespace=$(kubectl config view -o jsonpath="{.contexts[?(@.name == \"$(kubectl config current-context)\")].context.namespace}")
   echo "${_namespace:-default}"
@@ -82,7 +81,7 @@ if [[ ${#positional[@]} -ne 1 ]]; then
 fi
 
 node=${positional[0]}
-image=${image:-$default_image}
+image=${default_image:-"eu.gcr.io/gardener-project/gardener/ops-toolbelt:latest"}
 namespace=${namespace:-$(get_default_namespace)}
 
 node_of_pod=$(kubectl -n ${namespace} get pod ${node} -o jsonpath={.spec.nodeName} 2> /dev/null || true)


### PR DESCRIPTION
**What this PR does / why we need it**:
The current image:latest setup is able to access the shoot node, but when I try to access the seed node, I find `default_image` not able to use `export` value from `env`

<img width="1754" alt="image" src="https://github.com/gardener/ops-toolbelt/assets/42234376/4898515c-4478-4217-9564-c145636dc351">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
