### PR TITLE
Add etcdctl to image

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -80,6 +80,16 @@
     version: v1.26.9
     from: https://dl.k8s.io/release/{version}/bin/linux/amd64/kubectl
     info: command line tool for controlling Kubernetes clusters.
+  - name: etcdctl
+    version: 3.4.26
+    from: https://github.com/coreos/etcd/releases/download/v{version}/etcd-v{version}-linux-amd64.tar.gz
+    to: /etcd-linux-amd64.tar.gz
+    command: |
+      tar xzvf etcd-linux-amd64.tar.gz &&\
+      cp etcd-v3.4.26-linux-amd64/etcdctl /usr/local/bin/ &&\
+      rm -f etcd-linux-amd64.tar.gz &&\
+      rm -rf etcd-v3.4.26-linux-amd64 etcd-v3.4.26-linux-amd64
+    info: etcdctl is a simple command line client to interact with etcd
 
 - bash:
   - name: generate_locale


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `etcdctl` to the ops image so that it can be used to interact with and debug the etcd database

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Added etcdctl to the image
```
