### PR TITLE
fix default image

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Starting a pod with the ops-toolbel timage requires a running Kubelet and health
 #### Running a container locally
 The simplest way of using the `ops-toolbelt` is to just run the following command:
 ```bash
-$ docker run -it eu.gcr.io/gardener-project/gardener/ops-toolbelt:latest
+$ docker run -it eu.gcr.io/sap-se-gcr-k8s-public/eu_gcr_io/gardener-project/gardener/ops-toolbelt:latest
 
   __ _  __ _ _ __ __| | ___ _ __   ___ _ __   ___| |__   ___| | |
  / _` |/ _` | '__/ _` |/ _ \ '_ \ / _ \ '__| / __| '_ \ / _ \ | |

--- a/hacks/ops-pod
+++ b/hacks/ops-pod
@@ -34,7 +34,7 @@ Options:
                        effect: NoExecute
                      - key: CriticalAddonsOnly
                        operator: Exists
-  -i|--image        Image to use for the privileged pod. The default value is: eu.gcr.io/gardener-project/gardener/ops-toolbelt:latest
+  -i|--image        Image to use for the privileged pod. The default value is: eu.gcr.io/sap-se-gcr-k8s-public/eu_gcr_io/gardener-project/gardener/ops-toolbelt:latest
   -c|--chroot       When this flag is set the host's root directory will also be used as root directory of the pod. By default the host's
                     root directory is mounted under /host on the pod.
   -o|--hostnetwork  Whether to change the hostNetwork attribute to true.
@@ -60,7 +60,7 @@ sanitize_hostname() {
 }
 name="$(sanitize_hostname "ops-pod-$(whoami)")"
 
-default_image="eu.gcr.io/gardener-project/gardener/ops-toolbelt:latest"
+default_image="eu.gcr.io/sap-se-gcr-k8s-public/eu_gcr_io/gardener-project/gardener/ops-toolbelt:latest"
 function get_default_namespace() {
   _namespace=$(kubectl config view -o jsonpath="{.contexts[?(@.name == \"$(kubectl config current-context)\")].context.namespace}")
   echo "${_namespace:-default}"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix the default image address to avoid error  `Forbidden: no valid signature found for image eu.gcr.io/gardener-project/gardener/ops-toolbelt`

```
./ops-pod  shoot--seed-worker-z1-node
```

```
Node name provided ...
Deploying ops pod on  shoot--seed-worker-z1-node

Error from server (InternalError): error when creating "/dev/fd/63": Internal error occurred: failed calling webhook "verify-signature.seed.lakom.service.extensions.gardener.cloud": failed to call webhook: {"kind":"AdmissionReview","apiVersion":"admission.k8s.io/v1","response":{"uid":"99fecc395dde0","allowed":false,"status":{"metadata":{},"message":"pod.spec.containers[0].image: Forbidden: no valid signature found for image eu.gcr.io/gardener-project/gardener/ops-toolbelt@sha256:f7eb57413fcbe6f0a08d507426615d6b61488de","reason":"Forbidden","code":403}}}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Changed the default `ops-toolbelt` container image to `eu.gcr.io/sap-se-gcr-k8s-public/eu_gcr_io/gardener-project/gardener/ops-toolbelt:latest`
```
