### PR TITLE
Add script to install `etcdctl` on demand

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -115,7 +115,7 @@
     from: ./hacks/install_etcdctl
     to: /nonroot/hacks
     command: --chown=65532:65532
-    info: Bash script which installs the `etcdctl` tool in the container.
+    info: Bash script which installs the `etcdctl` tool in the container. If you are running this container as non-root, execute the `install-etcdctl` script in the `/nonroot/hacks` directory.
 
 - bash:
   - name: bash-completion

--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -105,6 +105,19 @@
     info: ~
 
 - bash:
+  - name: mkdir-nonroot
+    command: |
+      mkdir -p /nonroot && mkdir -p /nonroot/hacks && chown 65532:65532 -R /nonroot
+    info: create a folder `nonroot` and change permissions. Intended to be used by nonroot users.
+
+- copy:
+  - name: nonroot-hacks
+    from: ./hacks/install_etcdctl
+    to: /nonroot/hacks
+    command: --chown=65532:65532
+    info: ~
+
+- bash:
   - name: bash-completion
     command: |
       echo "" >> /root/.bashrc;\

--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -108,14 +108,14 @@
   - name: /nonroot/hacks
     command: |
       mkdir -p /nonroot && mkdir -p /nonroot/hacks && chown 65532:65532 -R /nonroot
-    info: create a folder `nonroot` and change permissions. Intended to be used by nonroot users.
+    info: A directory intended to be used by nonroot users.
 
 - copy:
-  - name: nonroot-hacks
+  - name: install_etcdctl
     from: ./hacks/install_etcdctl
     to: /nonroot/hacks
     command: --chown=65532:65532
-    info: ~
+    info: Bash script which installs the `etcdctl` tool in the container.
 
 - bash:
   - name: bash-completion

--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -105,7 +105,7 @@
     info: ~
 
 - bash:
-  - name: mkdir-nonroot
+  - name: /nonroot/hacks
     command: |
       mkdir -p /nonroot && mkdir -p /nonroot/hacks && chown 65532:65532 -R /nonroot
     info: create a folder `nonroot` and change permissions. Intended to be used by nonroot users.

--- a/generator/lib/commands.py
+++ b/generator/lib/commands.py
@@ -155,7 +155,7 @@ class InfoGenerator:
                 apt_get_commands.extend(InfoGenerator._get_package_name_and_bins(command))
             if isinstance(command, Pip):
                 pip_commands.extend(InfoGenerator._get_package_name_and_bins(command))
-            if isinstance(command, (Curl, Git, Execute)):
+            if isinstance(command, (Curl, Git, Execute, Copy)):
                 command_tools = command.get_tools()
                 for tool in command_tools:
                     if tool.get_info() is not None:

--- a/generator/lib/commands.py
+++ b/generator/lib/commands.py
@@ -76,7 +76,10 @@ class Copy(Command):
 
     def get_lines(self):
         for component in self.components:
-            yield "{} {}".format(component.get_from(), component.get_to())
+            if component.get_command() is None:
+                yield "{} {}".format(component.get_from(), component.get_to())
+            else:
+                yield "{} {} {}".format(component.get_command(), component.get_from(), component.get_to())
 
 class Pip(Command):
     def __init__(self, components):

--- a/hacks/install_etcdctl
+++ b/hacks/install_etcdctl
@@ -41,6 +41,8 @@ function install () {
 
 
   echo "You can now start using etcdctl. Just execute \"etcdctl\" to use it. See https://etcd.io/docs/v3.4/dev-guide/interacting_v3/ for more details."
+  echo "This tool assumes that it is being run in an ephemeral container in a pod. If this is not the case then please ensure that you provide the correct ecrtificates, the correct endpoint and have all necessary accesses"
+  echo "Certificates to be passed to the command should be mounted onto any container in the pod having a shared process namespace. Please run \"ps -A\" to list all processes and then access the certificates using \"/proc/<proc number>/root/<file-path>\". Pass these certificate file paths to the etcdctl command :)"
 }
 
 case "$1" in

--- a/hacks/install_etcdctl
+++ b/hacks/install_etcdctl
@@ -41,7 +41,7 @@ function install () {
 
 
   echo "You can now start using etcdctl. Just execute \"etcdctl\" to use it. See https://etcd.io/docs/v3.4/dev-guide/interacting_v3/ for more details."
-  echo "This tool assumes that it is being run in an ephemeral container in a pod. If this is not the case then please ensure that you provide the correct ecrtificates, the correct endpoint and have all necessary accesses"
+  echo "This tool assumes that it is being run in an ephemeral container in a pod. If this is not the case then please ensure that you provide the correct ecrtificates, the correct endpoint and have all necessary accesses."
   echo "Certificates to be passed to the command should be mounted onto any container in the pod having a shared process namespace. Please run \"ps -A\" to list all processes and then access the certificates using \"/proc/<proc number>/root/<file-path>\". Pass these certificate file paths to the etcdctl command :)"
 }
 

--- a/hacks/install_etcdctl
+++ b/hacks/install_etcdctl
@@ -1,0 +1,59 @@
+#!/bin/bash -e
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function show_help () {
+  echo "Usage: ${0} [arguments]"
+  echo "Possible arguments:"
+  echo "-h, --help       Show this help message and exit"
+  echo "-v, --version    Optional: specify etcdctl version to use. Default: version v3.4.26 will be installed."
+}
+
+function install () {
+  local version=$1
+  local download_url
+
+  if [ -z "$version" ]
+  then # fetch v3.4.26
+    version="v3.4.26"
+  else
+    if [[ ! $version == v* ]]
+    then
+      version="v${version}"
+    fi
+  fi
+
+  echo "installing etcdctl version ${version}"
+  download_url="https://github.com/coreos/etcd/releases/download/${version}/etcd-${version}-linux-amd64.tar.gz"
+
+  curl -sL ${download_url} -o etcd-${version}-linux-amd64.tar.gz && tar -zxvf etcd-${version}-linux-amd64.tar.gz && mv etcd-${version}-linux-amd64/etcdctl . && rm etcd-${version}-linux-amd64.tar.gz && rm -r etcd-${version}-linux-amd64
+
+
+  echo "You can now start using etcdctl. Just execute \"etcdctl\" to use it. See https://etcd.io/docs/v3.4/dev-guide/interacting_v3/ for more details."
+}
+
+case "$1" in
+  --version | -v)
+    install "$2"
+    exit
+    ;;
+  --help | -h)
+    show_help
+    exit
+    ;;
+  *)
+    install
+    exit
+    ;;
+esac


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an installer script to install `etcdctl` on demand which can be used to interact with and debug the etcd database

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
* I have created a new folder `/nonroot` with a nonroot owner (`65532`). This is because the etcd pod has a `PodSecurityContext` that runs as a nonroot user. This means that when we exec into it using this image we do so using a nonroot user and hence this script file needs to be owned by this nonroot user and the containing folder had to be owned by the nonroot user
* The `etcdctl` binary could also not be copied to `/usr/local/bin` since we needed root privileges for that. Instead, I propose to have the binary reside in `/nonroot/hacks/` itself when needed, but it can be used as is

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Added an installer script to install etcdctl on demand whenever needed
```
