### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,17 +1,18 @@
 ops-toolbelt:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
+        ocm_repository_mappings:
+          - repository: europe-docker.pkg.dev/gardener-project/releases
       publish:
         dockerimages:
           ops-toolbelt:
-            registry: 'gcr-readwrite'
-            image: 'eu.gcr.io/gardener-project/gardener/ops-toolbelt'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/ops-toolbelt
             dockerfile: ops-toolbelt.dockerfile
             inputs:
               steps:
@@ -32,7 +33,6 @@ ops-toolbelt:
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
         draft_release: ~
     pull-request:
       traits:
@@ -53,4 +53,7 @@ ops-toolbelt:
         publish:
           dockerimages:
             ops-toolbelt:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt
               tag_as_latest: true
+              extra_push_targets:
+                - eu.gcr.io/gardener-project/gardener/ops-toolbelt

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Starting a pod with the ops-toolbel timage requires a running Kubelet and health
 #### Running a container locally
 The simplest way of using the `ops-toolbelt` is to just run the following command:
 ```bash
-$ docker run -it eu.gcr.io/sap-se-gcr-k8s-public/eu_gcr_io/gardener-project/gardener/ops-toolbelt:latest
+$ docker run -it europe-docker.pkg.dev/sap-se-gcp-k8s-delivery/releases-public/eu_gcr_io/gardener-project/gardener/ops-toolbelt:latest
 
   __ _  __ _ _ __ __| | ___ _ __   ___ _ __   ___| |__   ___| | |
  / _` |/ _` | '__/ _` |/ _ \ '_ \ / _ \ '__| / __| '_ \ / _ \ | |

--- a/hacks/ops-pod
+++ b/hacks/ops-pod
@@ -34,7 +34,7 @@ Options:
                        effect: NoExecute
                      - key: CriticalAddonsOnly
                        operator: Exists
-  -i|--image        Image to use for the privileged pod. The default value is: eu.gcr.io/sap-se-gcr-k8s-public/eu_gcr_io/gardener-project/gardener/ops-toolbelt:latest
+  -i|--image        Image to use for the privileged pod. The default value is: europe-docker.pkg.dev/sap-se-gcp-k8s-delivery/releases-public/eu_gcr_io/gardener-project/gardener/ops-toolbelt:latest
   -c|--chroot       When this flag is set the host's root directory will also be used as root directory of the pod. By default the host's
                     root directory is mounted under /host on the pod.
   -o|--hostnetwork  Whether to change the hostNetwork attribute to true.
@@ -60,7 +60,7 @@ sanitize_hostname() {
 }
 name="$(sanitize_hostname "ops-pod-$(whoami)")"
 
-default_image="eu.gcr.io/sap-se-gcr-k8s-public/eu_gcr_io/gardener-project/gardener/ops-toolbelt:latest"
+default_image="europe-docker.pkg.dev/sap-se-gcp-k8s-delivery/releases-public/eu_gcr_io/gardener-project/gardener/ops-toolbelt:latest"
 function get_default_namespace() {
   _namespace=$(kubectl config view -o jsonpath="{.contexts[?(@.name == \"$(kubectl config current-context)\")].context.namespace}")
   echo "${_namespace:-default}"


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases

To allow users for smooth transitioning, keep also publishing to GCR.

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr

**Special notes for your reviewer**: In case there are no known users except Gardener's main sponsor, we could drop `extra_push_targets` from `.ci/pipeline_definitions`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Change OCI Registry for toolbelt image from GCR (eu.gcr.io/gardener-project) to Artifact-Registry (europe-docker.pkg.dev/gardener-project/releases).
```
