### PR TITLE
Bump kubectl and nerdctl

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -66,7 +66,7 @@
     from: https://raw.githubusercontent.com/johanhaleby/kubetail/master/kubetail
     info: Bash script that enables you to aggregate (tail/follow) logs from multiple pods into one stream
   - name: nerdctl
-    version: 1.7.2
+    version: 1.7.3
     from: https://github.com/containerd/nerdctl/releases/download/v{version}/nerdctl-{version}-linux-amd64.tar.gz
     to: /nerdctl.tar.gz
     command: |
@@ -77,7 +77,7 @@
       echo namespace = \"k8s.io\" >> /etc/nerdctl/nerdctl.toml
     info: nerdctl is a Docker-compatible CLI for containerd. The root directory of the host has to be mounted under `/host`
   - name: kubectl
-    version: v1.27.9
+    version: v1.27.10
     from: https://dl.k8s.io/release/{version}/bin/linux/amd64/kubectl
     info: command line tool for controlling Kubernetes clusters.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumped cli versions:
- kubectl -> `v1.27.10`
- nerdctl -> `1.7.3`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Bumped cli versions:
- kubectl -> `v1.27.10`
- nerdctl -> `1.7.3`
```
