### PR TITLE
Add reuse github action

### DIFF
--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -1,0 +1,11 @@
+name: REUSE Compliance Check
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@a46482ca367aef4454a87620aa37c2be4b2f8106 # v3.0.0


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a reuse github action to ensure that future PRs are reuse compliant

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
related PR https://github.com/gardener/ops-toolbelt/pull/105

cc @RaphaelVogel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
