### PR TITLE
Publish releases to Google Artifact Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -43,7 +43,8 @@ ops-toolbelt:
         pull-request: ~
     release:
       traits:
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         version:
           preprocess: 'finalize'
         release:


### PR DESCRIPTION
**What this PR does / why we need it**:
Properly publish new releases to Google Artifact Registry.
[This trait overwrite](https://github.com/gardener/ops-toolbelt/blob/ce45abbdb2517e74c2d25cb86d889c0c13476e49/.ci/pipeline_definitions#L46) causes a Google Container Registry fallback.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Publish new versions of ops-toolbelt to europe-docker.pkg.dev/gardener-project/releases
```
