### PR TITLE
`etcdctl` precalculated argument values are validated before preset.

### DIFF
--- a/install_on_demand/.etcdctl
+++ b/install_on_demand/.etcdctl
@@ -20,6 +20,11 @@ function _etcdctl_prepend_args(){
   local cert_args=()
   local args=()
   local pid
+  local nc_timeout=5
+  local etcd_host="etcd-main-local"
+  local etcd_port=2379
+  local red="\033[1;31m"
+  local nc="\033[0m"
 
   pid="$(get_etcd_pid)"
   if [ "${pid}" == "" ]; then
@@ -36,16 +41,37 @@ function _etcdctl_prepend_args(){
   fi
 
   if _check_arg_present "--cert" "${args[@]}"; then
-    cert_args+=("--cert=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.crt")
+    if [ -f "/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.crt" ]; then
+      cert_args+=("--cert=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.crt")
+    else
+      echo "Certificate not found in the expected path." 1>&2
+      echo -e "${red}You can use --cert=/path/to/file${nc}" 1>&2
+    fi
   fi
   if _check_arg_present "--key" "${args[@]}"; then
-    cert_args+=("--key=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.key")
+    if [ -f "/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.key" ]; then
+      cert_args+=("--key=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.key")
+    else
+      echo "Key not found in the expected path." 1>&2
+      echo -e "${red}You can use --key=/path/to/file${nc}" 1>&2
+    fi
   fi
   if _check_arg_present "--cacert" "${args[@]}"; then
-    cert_args+=("--cacert=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/ca/bundle.crt")
+    if [ -f "/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/ca/bundle.crt" ]; then
+      cert_args+=("--cacert=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/ca/bundle.crt")
+    else
+      echo "CA certificate not found in the expected path." 1>&2
+      echo -e "${red}You can use --cacert=/path/to/file${nc}" 1>&2
+    fi
   fi
   if _check_arg_present "--endpoints" "${args[@]}"; then
-    cert_args+=("--endpoints=https://etcd-main-local:2379")
+    if nc -z -w "${nc_timeout}" "${etcd_host}" "${etcd_port}" 1>/dev/bull 2>/dev/null; then
+      cert_args+=("--endpoints=https://${etcd_host}:${etcd_port}")
+    else
+      echo "Could not connect to deffault etcd host - https://${etcd_host}:${etcd_port} for less than ${nc_timeout} seconds" 1>&2
+      # shellcheck disable=SC2016
+      echo -e "${red}You can use --endpoints=https://"'${ETCD_HOST}:${ETCD_PORT}'"${nc}" 1>&2
+    fi
   fi
   if _check_arg_present "--keepalive-timeout" "${args[@]}"; then
     cert_args+=("--keepalive-timeout=2m")

--- a/install_on_demand/.etcdctl
+++ b/install_on_demand/.etcdctl
@@ -24,7 +24,6 @@ function _etcdctl_prepend_args(){
   local etcd_host="etcd-main-local"
   local etcd_port=2379
   local yellow="\033[1;33m"
-  local green="\033[1;32m"
   local red="\033[1;31m"
   local nc="\033[0m"
   local cert_base_dir
@@ -62,7 +61,7 @@ function _etcdctl_prepend_args(){
       cert_args+=("--cert=${cert_base_dir}/tls.crt")
     else
       log_colored "${yellow}" "TLS certificate not found in the expected path (${crt_path})."
-      log_colored "${green}" "You can use --cert=/path/to/file"
+      log_colored "${nc}" "You can use --cert=/path/to/file"
     fi
   fi
   if _check_arg_present "--key" "${args[@]}"; then
@@ -70,7 +69,7 @@ function _etcdctl_prepend_args(){
       cert_args+=("--key=${key_path}")
     else
       log_colored "${yellow}" "TLS key not found in the expected path (${key_path})."
-      echo -e "${green}You can use --key=/path/to/file${nc}" 1>&2
+      log_colored "${nc}" "You can use --key=/path/to/file"
     fi
   fi
   if _check_arg_present "--cacert" "${args[@]}"; then
@@ -78,7 +77,7 @@ function _etcdctl_prepend_args(){
       cert_args+=("--cacert=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/ca/bundle.crt")
     else
       log_colored "${yellow}" "CA certificate not found in the expected path (${ca_path})."
-      log_colored "${green}" "You can use --cacert=/path/to/file" 1>&2
+      log_colored "${nc}" "You can use --cacert=/path/to/file"
     fi
   fi
   if _check_arg_present "--endpoints" "${args[@]}"; then
@@ -87,7 +86,7 @@ function _etcdctl_prepend_args(){
     else
       log_colored "${yellow}" "etcd host https://${etcd_host}:${etcd_port} not reachable within ${nc_timeout} seconds."
       # shellcheck disable=SC2016
-      log_colored "${green}You can use --endpoints=https://"'${ETCD_HOST}:${ETCD_PORT}'
+      log_colored "${nc}" "You can use --endpoints=https://"'${ETCD_HOST}:${ETCD_PORT}'
     fi
   fi
   if _check_arg_present "--keepalive-timeout" "${args[@]}"; then

--- a/install_on_demand/.etcdctl
+++ b/install_on_demand/.etcdctl
@@ -68,7 +68,7 @@ function _etcdctl_prepend_args(){
     if nc -z -w "${nc_timeout}" "${etcd_host}" "${etcd_port}" 1>/dev/bull 2>/dev/null; then
       cert_args+=("--endpoints=https://${etcd_host}:${etcd_port}")
     else
-      echo "Could not connect to deffault etcd host - https://${etcd_host}:${etcd_port} for less than ${nc_timeout} seconds" 1>&2
+      echo "etcd host https://${etcd_host}:${etcd_port} not reachable within ${nc_timeout} seconds" 1>&2
       # shellcheck disable=SC2016
       echo -e "${red}You can use --endpoints=https://"'${ETCD_HOST}:${ETCD_PORT}'"${nc}" 1>&2
     fi

--- a/install_on_demand/.etcdctl
+++ b/install_on_demand/.etcdctl
@@ -52,7 +52,7 @@ function _etcdctl_prepend_args(){
     if [ -f "/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.key" ]; then
       cert_args+=("--key=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.key")
     else
-      echo "Key not found in the expected path." 1>&2
+      echo "TLS key not found in the expected path." 1>&2
       echo -e "${red}You can use --key=/path/to/file${nc}" 1>&2
     fi
   fi

--- a/install_on_demand/.etcdctl
+++ b/install_on_demand/.etcdctl
@@ -23,12 +23,25 @@ function _etcdctl_prepend_args(){
   local nc_timeout=5
   local etcd_host="etcd-main-local"
   local etcd_port=2379
+  local yellow="\033[1;33m"
+  local green="\033[1;32m"
   local red="\033[1;31m"
   local nc="\033[0m"
+  local cert_base_dir
+  local crt_path
+  local key_path
+  local ca_path
+
+  # print colored messages to stderr, first arg being the color
+  function log_colored(){
+      local color="${1}"
+      shift
+      echo -e "${color}${*}${nc}" 1>&2
+    }
 
   pid="$(get_etcd_pid)"
   if [ "${pid}" == "" ]; then
-    echo "etcd is not running" 1>&2
+    log_colored "${red}" "etcd is not running locally"
     return
   fi
   if [ "${#}" -ne 0 ]; then
@@ -40,37 +53,41 @@ function _etcdctl_prepend_args(){
     return
   fi
 
+  cert_base_dir="/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client"
+  crt_path="${cert_base_dir}/tls.crt"
+  key_path="${cert_base_dir}/tls.key"
+  ca_path="${cert_base_dir}/ca/bundle.crt"
   if _check_arg_present "--cert" "${args[@]}"; then
-    if [ -f "/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.crt" ]; then
-      cert_args+=("--cert=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.crt")
+    if [ -f "${crt_path}" ]; then
+      cert_args+=("--cert=${cert_base_dir}/tls.crt")
     else
-      echo "TLS certificate not found in the expected path." 1>&2
-      echo -e "${red}You can use --cert=/path/to/file${nc}" 1>&2
+      log_colored "${yellow}" "TLS certificate not found in the expected path (${crt_path})."
+      log_colored "${green}" "You can use --cert=/path/to/file"
     fi
   fi
   if _check_arg_present "--key" "${args[@]}"; then
-    if [ -f "/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.key" ]; then
-      cert_args+=("--key=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.key")
+    if [ -f "${key_path}" ]; then
+      cert_args+=("--key=${key_path}")
     else
-      echo "TLS key not found in the expected path." 1>&2
-      echo -e "${red}You can use --key=/path/to/file${nc}" 1>&2
+      log_colored "${yellow}" "TLS key not found in the expected path (${key_path})."
+      echo -e "${green}You can use --key=/path/to/file${nc}" 1>&2
     fi
   fi
   if _check_arg_present "--cacert" "${args[@]}"; then
-    if [ -f "/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/ca/bundle.crt" ]; then
+    if [ -f "${ca_path}" ]; then
       cert_args+=("--cacert=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/ca/bundle.crt")
     else
-      echo "CA certificate not found in the expected path." 1>&2
-      echo -e "${red}You can use --cacert=/path/to/file${nc}" 1>&2
+      log_colored "${yellow}" "CA certificate not found in the expected path (${ca_path})."
+      log_colored "${green}" "You can use --cacert=/path/to/file" 1>&2
     fi
   fi
   if _check_arg_present "--endpoints" "${args[@]}"; then
     if nc -z -w "${nc_timeout}" "${etcd_host}" "${etcd_port}" 1>/dev/bull 2>/dev/null; then
       cert_args+=("--endpoints=https://${etcd_host}:${etcd_port}")
     else
-      echo "etcd host https://${etcd_host}:${etcd_port} not reachable within ${nc_timeout} seconds" 1>&2
+      log_colored "${yellow}" "etcd host https://${etcd_host}:${etcd_port} not reachable within ${nc_timeout} seconds."
       # shellcheck disable=SC2016
-      echo -e "${red}You can use --endpoints=https://"'${ETCD_HOST}:${ETCD_PORT}'"${nc}" 1>&2
+      log_colored "${green}You can use --endpoints=https://"'${ETCD_HOST}:${ETCD_PORT}'
     fi
   fi
   if _check_arg_present "--keepalive-timeout" "${args[@]}"; then

--- a/install_on_demand/.etcdctl
+++ b/install_on_demand/.etcdctl
@@ -44,7 +44,7 @@ function _etcdctl_prepend_args(){
     if [ -f "/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.crt" ]; then
       cert_args+=("--cert=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client/tls.crt")
     else
-      echo "Certificate not found in the expected path." 1>&2
+      echo "TLS certificate not found in the expected path." 1>&2
       echo -e "${red}You can use --cert=/path/to/file${nc}" 1>&2
     fi
   fi


### PR DESCRIPTION
**What this PR does / why we need it**:
`etcdctl` precalculated argument values are validated before preset.
If deemed inappropriate hinting message is printed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`etcdctl` precalculated arguments are validated before set. If deemed inappropriate, hint is printed for the operator to set the correct values.
```
