### PR TITLE
Fixes the path for cacert used in etcdctl.

### DIFF
--- a/hacks/print-etcd-cheatsheet
+++ b/hacks/print-etcd-cheatsheet
@@ -15,6 +15,11 @@ function get_backup_restore_process_id() {
   echo "${process_id}"
 }
 
+function get_etcd_host() {
+  etcd_host=$(hostname | sed "s/[0-9]/local/")
+  echo "${etcd_host}"
+}
+
 wrapper_pid=$(get_wrapper_process_id)
 if [[ -z "$wrapper_pid" ]]; then
 	echo "error: cannot find the process id for etcd-wrapper. Please ensure it is running"
@@ -25,6 +30,8 @@ if [[ -z "$backup_restore_pid" ]]; then
 	echo "error: cannot find the process id for backup-restore. Please ensure it is running"
 	exit 1
 fi
+
+etcd_host=$(get_etcd_host)
 
 cat <<EOF
  📌 ETCD PKI resource paths:
@@ -49,7 +56,7 @@ cat <<EOF
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
-  --endpoints=https://etcd-main-local:2379
+  --endpoints=https://${etcd_host}:2379
 
   Update etcd member peer URL:
   etcdctl member update <member-id> \\
@@ -57,42 +64,42 @@ cat <<EOF
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
-  --endpoints=https://etcd-main-local:2379
+  --endpoints=https://${etcd_host}:2379
 
   Get endpoint status for the etcd cluster:
   etcdctl endpoint -w table --cluster status \\
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
-  --endpoints=https://etcd-main-local:2379
+  --endpoints=https://${etcd_host}:2379
 
   List all alarms:
   etcdctl alarm list \\
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
-  --endpoints=https://etcd-main-local:2379
+  --endpoints=https://${etcd_host}:2379
 
   Disarm all alarms:
   etcdctl alarm disarm \\
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
-  --endpoints=https://etcd-main-local:2379
+  --endpoints=https://${etcd_host}:2379
 
   Defragment etcd:
   etcdctl defrag \\
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
-  --endpoints=https://etcd-main-local:2379
+  --endpoints=https://${etcd_host}:2379
 
   Change leadership:
   etcdctl move-leader <new-leader-member-id> \\
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
-  --endpoints=https://etcd-main-local:2379
+  --endpoints=https://${etcd_host}:2379
 
  📌 ETCD Key-Value commands:
   --------------------------------------------------
@@ -102,27 +109,27 @@ cat <<EOF
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
-  --endpoints=https://etcd-main-local:2379
+  --endpoints=https://${etcd_host}:2379
 
   Get only value for a given key:
   etcdctl get <key> --print-value-only \\
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
-  --endpoints=https://etcd-main-local:2379
+  --endpoints=https://${etcd_host}:2379
 
   List all keys:
   etcdctl get "" --prefix --keys-only \\
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
-  --endpoints=https://etcd-main-local:2379
+  --endpoints=https://${etcd_host}:2379
 
   Put a value against a key:
   etcdctl put <key> <value> \\
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
-  --endpoints=https://etcd-main-local:2379
+  --endpoints=https://${etcd_host}:2379
 
 EOF

--- a/install_on_demand/.etcdctl
+++ b/install_on_demand/.etcdctl
@@ -58,7 +58,7 @@ function _etcdctl_prepend_args(){
   ca_path="${cert_base_dir}/ca/bundle.crt"
   if _check_arg_present "--cert" "${args[@]}"; then
     if [ -f "${crt_path}" ]; then
-      cert_args+=("--cert=${cert_base_dir}/tls.crt")
+      cert_args+=("--cert=${crt_path}")
     else
       log_colored "${yellow}" "TLS certificate not found in the expected path (${crt_path})."
       log_colored "${nc}" "You can use --cert=/path/to/file"
@@ -74,7 +74,7 @@ function _etcdctl_prepend_args(){
   fi
   if _check_arg_present "--cacert" "${args[@]}"; then
     if [ -f "${ca_path}" ]; then
-      cert_args+=("--cacert=/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/ca/bundle.crt")
+      cert_args+=("--cacert=${ca_path}")
     else
       log_colored "${yellow}" "CA certificate not found in the expected path (${ca_path})."
       log_colored "${nc}" "You can use --cacert=/path/to/file"

--- a/install_on_demand/.etcdctl
+++ b/install_on_demand/.etcdctl
@@ -21,7 +21,7 @@ function _etcdctl_prepend_args(){
   local args=()
   local pid
   local nc_timeout=5
-  local etcd_host="etcd-main-local"
+  local etcd_host
   local etcd_port=2379
   local yellow="\033[1;33m"
   local red="\033[1;31m"
@@ -39,6 +39,7 @@ function _etcdctl_prepend_args(){
     }
 
   pid="$(get_etcd_pid)"
+  etcd_host="$(get_etcd_host)"
   if [ "${pid}" == "" ]; then
     log_colored "${red}" "etcd is not running locally"
     return
@@ -119,4 +120,8 @@ function _check_arg_present(){
 
 function get_etcd_pid() {
   pgrep wrapper
+}
+
+function get_etcd_host() {
+  uname -a | awk '{print $2}' | sed "s/[0-9]/local/"
 }

--- a/install_on_demand/.etcdctl
+++ b/install_on_demand/.etcdctl
@@ -52,9 +52,9 @@ function _etcdctl_prepend_args(){
     return
   fi
 
-  cert_base_dir="/proc/$(get_etcd_pid)/root/var/etcd/ssl/client/client"
-  crt_path="${cert_base_dir}/tls.crt"
-  key_path="${cert_base_dir}/tls.key"
+  cert_base_dir="/proc/$(get_etcd_pid)/root/var/etcd/ssl/client"
+  crt_path="${cert_base_dir}/client/tls.crt"
+  key_path="${cert_base_dir}/client/tls.key"
   ca_path="${cert_base_dir}/ca/bundle.crt"
   if _check_arg_present "--cert" "${args[@]}"; then
     if [ -f "${crt_path}" ]; then
@@ -81,7 +81,7 @@ function _etcdctl_prepend_args(){
     fi
   fi
   if _check_arg_present "--endpoints" "${args[@]}"; then
-    if nc -z -w "${nc_timeout}" "${etcd_host}" "${etcd_port}" 1>/dev/bull 2>/dev/null; then
+    if nc -z -w "${nc_timeout}" "${etcd_host}" "${etcd_port}" 1>/dev/null 2>/dev/null; then
       cert_args+=("--endpoints=https://${etcd_host}:${etcd_port}")
     else
       log_colored "${yellow}" "etcd host https://${etcd_host}:${etcd_port} not reachable within ${nc_timeout} seconds."

--- a/install_on_demand/.etcdctl
+++ b/install_on_demand/.etcdctl
@@ -90,18 +90,7 @@ function _etcdctl_prepend_args(){
       log_colored "${nc}" "You can use --endpoints=https://"'${ETCD_HOST}:${ETCD_PORT}'
     fi
   fi
-  if _check_arg_present "--keepalive-timeout" "${args[@]}"; then
-    cert_args+=("--keepalive-timeout=2m")
-  fi
-  if _check_arg_present "--keepalive-time" "${args[@]}"; then
-    cert_args+=("--keepalive-time=2m")
-  fi
-  if _check_arg_present "--dial-timeout" "${args[@]}"; then
-    cert_args+=("--dial-timeout=2m")
-  fi
-  if _check_arg_present "--dial-timeout" "${args[@]}"; then
-    cert_args+=("--dial-timeout=2m")
-  fi
+
   args=("${args[@]}" "${cert_args[@]}")
   echo "${args[*]}"
 }

--- a/install_on_demand/.etcdctl
+++ b/install_on_demand/.etcdctl
@@ -123,5 +123,5 @@ function get_etcd_pid() {
 }
 
 function get_etcd_host() {
-  uname -a | awk '{print $2}' | sed "s/[0-9]/local/"
+  hostname | sed "s/[0-9]/local/"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the precalculated argument value of `cacert` path used in `etcdctl` command

**Which issue(s) this PR fixes**:
Fixes #118 and #120

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes the precalculated argument CA certificate path used for the etcdctl command
```
