### PR TITLE
[renovate] Add release notes for github-releases

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,8 @@
     "group:monorepos"
   ],
   labels: ["kind/enhancement"],
+  // Add PR footer with empty release note by default.
+  prFooter: "**Release note**:\n```other dependency\nNONE\n```",
   customManagers: [
     {
       // Update `_VERSION` and `_version` variables in Makefiles and scripts.
@@ -44,6 +46,11 @@
       matchPackageNames: ["kubernetes/kubernetes"],
       // This is a compromise due to the version skew policy of Kubernetes.
       allowedVersions: "~1.28"
+    },
+    {
+      // Add PR footer with release notes link for github-releases.
+      matchDatasources: ["github-releases"],
+      prFooter: "**Release note**:\n```other dependency\n`{{depName}}` has been updated to `{{newVersion}}`. [Release Notes](https://github.com/{{depName}}/releases/tag/{{newVersion}})\n```"
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that release notes are added to PRs for `github-releases` datasource

Example:
![Screenshot 2024-05-24 at 12 11 05](https://github.com/gardener/ops-toolbelt/assets/5526658/6e0517dc-10cd-434e-af08-b0405136e3c3)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
