### PR TITLE
Drop `dstat` and `python3-distutils` packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ Deploying ops pod on node1
 pod/ops-pod created
 Waiting for pod to be running...
 Waiting for pod to be running...
-This container comes with the following preinstalled tools:
-curl tree silversearcher-ag htop less vim tmux bash-completion dnsutils netcat-openbsd iproute2 dstat ngrep tcpdump python-minimal jq yaml2json kubectl pip cat mdv
+                     _                            _          _ _
+  __ _  __ _ _ __ __| | ___ _ __   ___ _ __   ___| |__   ___| | |
+ / _` |/ _` | '__/ _` |/ _ \ '_ \ / _ \ '__| / __| '_ \ / _ \ | |
+| (_| | (_| | | | (_| |  __/ | | |  __/ |    \__ \ | | |  __/ | |
+ \__, |\__,_|_|  \__,_|\___|_| |_|\___|_|    |___/_| |_|\___|_|_|
+ |___/
 
-The sourced dotfiles are located under /root/dotfiles.
-Additionally you can add your own personal git settings in /root/dotfiles/.config/git/config_personal
+Run ghelp to get information about installed tools and packages
 
-The following variables have been exported:
-DOTFILES_USER=root DOTFILES_HOME=/root/dotfiles
-
-root at node1 in /
+root at ops-pod in /
 $
 ```
 

--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -17,8 +17,6 @@
   - locales
   - tmux
   - bash-completion
-  - python3-distutils
-  - dstat
   - ngrep
   - iotop
   - iftop


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the build fails as these packages are not available anymore in the used package repository.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Dropped `dstat` and `python3-distutils` packages
```
