### PR TITLE
Renovate/gardenlinux gardenlinux 1592.x

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -17,6 +17,7 @@
   - locales
   - tmux
   - bash-completion
+  - procps
   - ngrep
   - iotop
   - iftop

--- a/generator/validate-tools.py
+++ b/generator/validate-tools.py
@@ -9,7 +9,7 @@ import subprocess
 import shlex
 import re
 
-from lib import dockerfile, commands, config_parser
+from lib import commands, config_parser
 
 def validate_tools(commands_list):
     errors = []
@@ -29,8 +29,10 @@ def validate_tools(commands_list):
                     errors.append('Command "{}" failed with exit code {}'.format(e.cmd, e.returncode))
     return errors
 
+
 parser = argparse.ArgumentParser()
-parser.add_argument("--dockerfile-configs", nargs='+', action="append", dest="dockerfile_configs", default=[], required=False, help="yaml file which lists the tools to be tested")
+parser.add_argument("--dockerfile-configs", nargs='+', action="append", dest="dockerfile_configs",
+                    default=[], required=False, help="yaml file which lists the tools to be tested")
 args = parser.parse_args()
 
 dockerfile_config = config_parser.parse_dockerfile_configs(args.dockerfile_configs)


### PR DESCRIPTION
**What this PR does / why we need it**:
Attempted to verify the renovate PR, seems now `pgrep` is no longer implicitly available.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I built the image and verified that there are no other missing executables in
the image (by running them in a local container).
/invite @plkokanov @petersutter 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
