### PR TITLE
Update etcdctl CA and TLS cert paths to support etcd-druid:v0.23.0

### DIFF
--- a/install_on_demand/.etcdctl
+++ b/install_on_demand/.etcdctl
@@ -53,7 +53,7 @@ function _etcdctl_prepend_args(){
     return
   fi
 
-  cert_base_dir="/proc/$(get_etcd_pid)/root/var/etcd/ssl/client"
+  cert_base_dir="/proc/$(get_etcd_pid)/root/var/etcd/ssl"
   crt_path="${cert_base_dir}/client/tls.crt"
   key_path="${cert_base_dir}/client/tls.key"
   ca_path="${cert_base_dir}/ca/bundle.crt"


### PR DESCRIPTION
**What this PR does / why we need it**:
Update etcdctl CA and TLS cert paths to support etcd-druid:v0.23.0. Please refer to [release notes](https://github.com/gardener/etcd-druid/releases/tag/v0.23.0) for information on the same.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @unmarshall @ishan16696 
/hold until druid:v0.23.0 is merged into g/g and released.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update etcdctl CA and TLS cert paths to support etcd-druid:v0.23.0.
```
