### PR TITLE
Update print-etcd-cheatsheet

### DIFF
--- a/hacks/print-etcd-cheatsheet
+++ b/hacks/print-etcd-cheatsheet
@@ -119,7 +119,7 @@ cat <<EOF
   --endpoints=https://${etcd_host}:2379
 
   List all keys:
-  etcdctl get "" --prefix --keys-only \\
+  etcdctl get "/" --prefix --keys-only \\
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
@@ -127,6 +127,13 @@ cat <<EOF
 
   Put a value against a key:
   etcdctl put <key> <value> \\
+  --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
+  --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
+  --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\
+  --endpoints=https://${etcd_host}:2379
+
+  Put file content against a key:
+  cat <filename> | etcdctl put <key> \\
   --cacert=proc/${wrapper_pid}/root/var/etcd/ssl/client/ca/bundle.crt \\
   --cert=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.crt \\
   --key=proc/${wrapper_pid}/root/var/etcd/ssl/client/client/tls.key \\


### PR DESCRIPTION
**What this PR does / why we need it**:
- updated the get all keys command (old version errors with `Error: get command needs one argument as key and an optional argument as range_end`)
- added example to put file content into a key

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
