### PR TITLE
Bump `kubectl` version to 1.30.5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -45,7 +45,7 @@
       // Only create PRs for patch updates of kubectl.
       matchPackageNames: ["kubernetes/kubernetes"],
       // This is a compromise due to the version skew policy of Kubernetes.
-      allowedVersions: "~1.28"
+      allowedVersions: "~1.30"
     },
     {
       // Add PR footer with release notes link for github-releases.

--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -64,7 +64,7 @@
     info: nerdctl is a Docker-compatible CLI for containerd. The root directory of the host has to be mounted under `/host`
   - name: kubectl
     # renovate: datasource=github-releases depName=kubernetes/kubernetes
-    version: v1.28.15
+    version: v1.30.5
     from: https://dl.k8s.io/release/{version}/bin/linux/${{TARGETARCH}}/kubectl
     info: command line tool for controlling Kubernetes clusters.
 
@@ -104,7 +104,7 @@
     info: A directory intended to allow common install point for ad-hoc install scripts
 
 - copy:
-  - name: install_k9s 
+  - name: install_k9s
     from: ./hacks/install_k9s
     to: /nonroot/hacks
     command: --chown=65532:65532


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps the version of `kubectl` to `v1.30.5` and updates the renovate config so that it performs automatic patch updates for `v1.30`.

This is done because gardener now supports  k8s `v1.31`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`kubectl` has been updated to  `v1.30.5`. [Release Notes](https://togithub.com/kubernetes/kubernetes/releases/tag/v1.30.5)
```
