### PR TITLE
Correct the image in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Starting a pod with the `ops-toolbelt` image requires a running `Kubelet`, a hea
 The simplest way of using the `ops-toolbelt` is to just run the following command:
 
 ```bash
-$ docker run -it europe-docker.pkg.dev/sap-se-gcp-k8s-delivery/releases-public/eu_gcr_io/gardener-project/gardener/ops-toolbelt:latest
+$ docker run -it europe-docker.pkg.dev/gardener-project/releases/gardener/ops-toolbelt:latest
 
   __ _  __ _ _ __ __| | ___ _ __   ___ _ __   ___| |__   ___| | |
  / _` |/ _` | '__/ _` |/ _ \ '_ \ / _ \ '__| / __| '_ \ / _ \ | |


### PR DESCRIPTION
**What this PR does / why we need it**:

* All gardener projects specify images hosted in the `europe-docker.pkg.dev/gardener-project/releases/gardener` registry for public consumption in documentation and `README.md`. The previous image is corrected to use the right registry to stay consistent with the rest of the organization.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
The container registry that hosts the image for public consumption is specified in `README.md`.
```
