### PR TITLE
No err message on node found

### DIFF
--- a/hacks/ops-pod
+++ b/hacks/ops-pod
@@ -111,7 +111,7 @@ if [[ -n ${node_of_pod} ]]; then
 else
   echo "Node name provided ..."
   # shellcheck disable=SC2076
-  if [[ $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}') =~ " ${node} " ]]; then
+  if kubectl get nodes -o jsonpath='{.items[*].metadata.name}' | grep -q "\b${node}\b"; then
     echo -e "Deploying ops pod on ${node}\n"
   else
     echo -e "Error: node ${node} does not exist in the cluster.\n"

--- a/hacks/ops-pod
+++ b/hacks/ops-pod
@@ -110,12 +110,12 @@ if [[ -n ${node_of_pod} ]]; then
   node=$node_of_pod
 else
   echo "Node name provided ..."
-  # shellcheck disable=SC2076
   if kubectl get nodes -o jsonpath='{.items[*].metadata.name}' | grep -q "\b${node}\b"; then
     echo -e "Deploying ops pod on ${node}\n"
   else
     echo -e "Error: node ${node} does not exist in the cluster.\n"
     print_usage
+    exit 2
   fi
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
PR fixes the case where a node is found but err message is still printed in `hacks/ops-pod`.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
