### PR TITLE
Reintroducing ioutils

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -19,6 +19,8 @@
   - bash-completion
   - procps
   - ngrep
+  - iotop
+  - iftop
   - jq
   - figlet
   - tcpdump


### PR DESCRIPTION
**What this PR does / why we need it**:
Reintroduces io utils, removed in https://github.com/gardener/ops-toolbelt/pull/171

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Merge only after GL provides python 3.13.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
