### PR TITLE
fix for nativ readlink installation on macos

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -10,8 +10,8 @@ if [[ -z ${SOURCE_PATH} ]]; then
 fi
 
 if [[ -z "${GENERATED_DOCKERFILES_PATH}" ]]; then
+    mkdir -p "${SOURCE_PATH}/generated_dockerfiles"
     GENERATED_DOCKERFILES_PATH="$(readlink -f "${SOURCE_PATH}/generated_dockerfiles")"
-    mkdir -p "${GENERATED_DOCKERFILES_PATH}"
 fi
 
 "${SOURCE_PATH}"/generator/generate-dockerfile.py \


### PR DESCRIPTION
**What this PR does / why we need it**:
when the preinstalled version of `readlink` (on macos) is used to resolve a path with a dir that dose not exist, it returns the exit code 1 which crashed the `.ci/build` script. This issue wasn't noticed until now probably because as part of the local setup of gardener is to install the gnu core utilities with an up to date version.

`readlink` version: //unfortunatelyi am unable to extract the exact version of the installed command since the classic pathways like -v or --version do not seem to be supported. 
ProductName:            macOS
ProductVersion:         15.3.2
BuildVersion:           24D81


**Which issue(s) this PR fixes**:
exit code 1 for .ci/build script when recent gnu core utils are not installed

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
