### PR TITLE
Changing renovate config to follow currently set minor version and update patch versions for `kubectl`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,9 +43,17 @@
     },
     {
       // Only create PRs for patch updates of kubectl.
-      matchPackageNames: ["kubernetes/kubernetes"],
-      // This is a compromise due to the version skew policy of Kubernetes.
-      allowedVersions: "~1.32"
+      "matchPackageNames": ["kubernetes/kubernetes"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true
+    },
+    {
+      // Don't go wild with the minor version.
+      // Keep the currently supported within Gardener - 1 for minor version.
+      "matchPackageNames": ["kubernetes/kubernetes"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    }
     },
     {
       // Add PR footer with release notes link for github-releases.


### PR DESCRIPTION
**What this PR does / why we need it**:
PR reconfigures renovate config to follow the currently set minor version for `kubectl`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
```
