### PR TITLE
add auger and install when needed

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -112,6 +112,11 @@
     to: /nonroot/hacks
     command: --chown=65532:65532
     info: Bash script which installs the `etcdctl` tool in the container. If you are running this container as non-root, execute the `install_etcdctl` script in the `/nonroot/hacks` directory.
+  - name: install_auger
+    from: ./hacks/install_auger
+    to: /nonroot/hacks
+    command: --chown=65532:65532
+    info: Bash script which installs the `auger` tool in the container. If you are running this container as non-root, execute the `install_auger` script in the `/nonroot/hacks` directory.
 
 - copy:
   - name: print-etcd-cheatsheet

--- a/hacks/install_auger
+++ b/hacks/install_auger
@@ -1,0 +1,72 @@
+#!/bin/bash -e
+
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+function show_help () {
+  echo "Usage: ${0} [arguments]"
+  echo "Possible arguments:"
+  echo "-h, --help       Show this help message and exit"
+  echo "-v, --version    Optional: specify auger version to use. Default: latest version will be installed"
+}
+
+function install () {
+  local version=$1
+  local download_url
+  local yellow="\033[0;33m"
+  local nc="\033[0m"
+  local arch
+  local platform
+  local pkg
+  local dest
+  local version_url="https://api.github.com/repos/etcd-io/auger/releases/latest"
+
+  tmp_dir="$(mktemp -d)"
+  mkdir -p "${tmp_dir}/dest"
+
+  dest="/opt/bin/auger"
+  if uname="$(whoami 2> /dev/null)"; then
+    if [[ "${uname}" == "root" ]]; then
+      if [ -w "/usr/local/bin" ]; then
+        dest="/usr/local/bin/auger"
+      fi
+    fi
+  fi
+
+  if [ -z "$version" ]; then # fetch latest
+    version=$(curl -sL "${version_url}" | jq -r '.tag_name')
+  fi
+  pkg_version=${version/#v/}
+  arch=$(uname -m | sed 's/^x86_64$/amd64/;s/^aarch64$/arm64/')
+  platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  pkg="auger_${pkg_version}_${platform}_${arch}"
+
+  download_url="https://github.com/etcd-io/auger/releases/download/${version}/${pkg}.tar.gz"
+
+  curl -sL "${download_url}" \
+    -o "${tmp_dir}/${pkg}.tar.gz" && \
+    tar -zxf "${tmp_dir}/${pkg}.tar.gz" -C "${tmp_dir}/dest" && \
+    mv "${tmp_dir}/dest/auger" "${dest}" && \
+    chmod 755 "${dest}" && \
+    rm -rf "${tmp_dir}"
+
+  echo -e "${yellow}"
+  echo "You can now start using auger. Just execute \"auger\" to use it. See https://github.com/etcd-io/auger/blob/main/README.md#modify-data-via-etcdctl for examples"
+  echo -e "${nc}"
+}
+
+case "$1" in
+  --version | -v)
+    install "$2"
+    exit
+    ;;
+  --help | -h)
+    show_help
+    exit
+    ;;
+  *)
+    install
+    exit
+    ;;
+esac

--- a/install_on_demand/.auger
+++ b/install_on_demand/.auger
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+alias auger="auger_install"
+function auger_install() {
+  app="auger"
+  install_func='/nonroot/hacks/install_auger'
+
+  if ! hash "${app}" &>/dev/null; then
+    "${install_func}" 1>&2
+  fi
+
+  command "${app}" "$@"
+}

--- a/install_on_demand/.shrc
+++ b/install_on_demand/.shrc
@@ -8,5 +8,6 @@ source /etc/bash/install_on_demand/.table
 source /etc/bash/install_on_demand/.wireguard
 source /etc/bash/install_on_demand/.etcdctl
 source /etc/bash/install_on_demand/.k9s
+source /etc/bash/install_on_demand/.auger
 
 export PATH="/opt/bin:${PATH}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `auger` to the image. It should be installed only, when needed.

**Which issue(s) this PR fixes**:
Fixes #186 

**Special notes for your reviewer**:
/invite @mimiteto

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`auger` is available in the image now.
```
