### PR TITLE
Removing `perl-base` as it's not used

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -155,7 +155,7 @@
       echo "export PATH=/hacks:\$PATH" >> /root/.bashrc
     info: ~
   - name: cleanup
-    command: apt-get remove -y --allow-remove-essential perl-base
+    command: apt-get remove -y --allow-remove-essential perl-base; apt autoremove -y
     info: ~
 
 - env:


### PR DESCRIPTION
**What this PR does / why we need it**:
PR removes `perl-base` package.
PR also updates `kubectl` to 1.33.xx
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
perl is no longer available
```
