### PR TITLE
Added script to install etcd-benchmark on-demand.

### DIFF
--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -136,6 +136,11 @@
     to: /nonroot/hacks
     command: --chown=65532:65532
     info: Bash script which installs the `pwru` tool in the container. If you are running this container as non-root, execute the `install_pwru` script in the `/nonroot/hacks` directory.
+  - name: install_etcd-benchmark
+    from: ./hacks/install_etcd-benchmark
+    to: /nonroot/hacks
+    command: --chown=65532:65532
+    info: Bash script which installs the `etcd-benchmark` tool in the container. If you are running this container as non-root, execute the `install_etcd-benchmark` script in the `/nonroot/hacks` directory.
 
 - name: copy
   items:

--- a/hacks/install_etcd-benchmark
+++ b/hacks/install_etcd-benchmark
@@ -1,0 +1,68 @@
+#!/bin/bash -e
+
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+function show_help () {
+  echo "Usage: ${0} [arguments]"
+  echo "Possible arguments:"
+  echo "-h, --help       Show this help message and exit"
+}
+
+
+function install () {
+  etcd_benchmark_version="v0.1.0"
+  local version="${1:-${etcd_benchmark_version}}"
+  local download_url
+  local yellow="\033[0;33m"
+  local nc="\033[0m"
+  local arch
+  local platform
+  local dest
+  local tmp_dir
+  local pkg
+
+  tmp_dir="$(mktemp -d)"
+  mkdir -p "${tmp_dir}/dest"
+
+  dest="/opt/bin/benchmark"
+
+  if uname="$(whoami 2> /dev/null)"; then
+    if [[ "${uname}" == "root" ]]; then
+      if [ -w "/usr/local/bin" ]; then
+        dest="/usr/local/bin/benchmark"
+      fi
+    fi
+  fi
+
+  arch=$(uname -m | sed 's/^x86_64$/amd64/;s/^aarch64$/arm64/')
+  platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+
+  pkg="benchmark-${version}-${platform}-${arch}"
+
+  download_url="https://github.com/ishan16696/etcd-backup-restore/releases/download/${version}/${pkg}.tar.gz"
+
+  curl -sL "${download_url}" \
+    -o "${tmp_dir}/${pkg}.tar.gz" && \
+    tar -zxf "${tmp_dir}/${pkg}.tar.gz" -C "${tmp_dir}/dest" && \
+    mv "${tmp_dir}/dest/benchmark" "${dest}" && \
+    chmod 755 "${dest}" && \
+    rm -rf "${tmp_dir}"
+
+  echo -e "${yellow}"
+  echo "You can now start using etcd benchmark tool. Just execute \"benchmark\" to use it. For more details: https://github.com/etcd-io/etcd/blob/main/tools/benchmark/README.md"
+  echo -e "${nc}"
+}
+
+case "$1" in
+  --help | -h)
+    show_help
+    exit
+    ;;
+  *)
+    install
+    exit
+    ;;
+esac


### PR DESCRIPTION
**What this PR does / why we need it**:
To load the etcd database easily, this PR adds [etcd's benchmark tool](https://github.com/etcd-io/etcd/tree/main/tools/benchmark) to the image. It should be installed only, when needed.
After running the script, data can directly put into the etcd.
example:
```
benchmark put --key-space-size=100 --key-size 512 --val-size 1024  --total 10000 --clients=100
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @renormalize 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`etcd-benchmark` can be installed on-demand to load the etcd database.
```
