### PR TITLE
Introduce a cron to update kubectl versions

### DIFF
--- a/.github/workflows/update-kubectl-minor.yaml
+++ b/.github/workflows/update-kubectl-minor.yaml
@@ -1,0 +1,75 @@
+name: Update kubectl minor version
+
+on:
+  schedule:
+    - cron: "30 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-kubectl-minor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine desired kubectl minor version
+        id: version
+        run: |
+          # Fetch supported Kubernetes versions from gardener/gardener
+          curl -sL https://raw.githubusercontent.com/gardener/gardener/master/supported-kubernetes-versions.yaml -o versions.yaml
+
+          # Find highest supported minor version, subtract 1
+          HIGHEST_MINOR=$(yq '.versions[].version' versions.yaml | sort -V | tail -1 | cut -d. -f2)
+          DESIRED_MINOR=$((HIGHEST_MINOR - 0))
+
+          # Read current version from common-components.yaml
+          CURRENT_VERSION=$(yq '.. | select(has("name")) | select(.name == "kubectl") | .version' dockerfile-configs/common-components.yaml)
+          CURRENT_MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
+
+          echo "highest_minor=$HIGHEST_MINOR" >> "$GITHUB_OUTPUT"
+          echo "desired_minor=$DESIRED_MINOR" >> "$GITHUB_OUTPUT"
+          echo "current_minor=$CURRENT_MINOR" >> "$GITHUB_OUTPUT"
+          echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+
+          if [ "$CURRENT_MINOR" != "$DESIRED_MINOR" ]; then
+            echo "update_needed=true" >> "$GITHUB_OUTPUT"
+            echo "new_version=v1.${DESIRED_MINOR}.0" >> "$GITHUB_OUTPUT"
+          else
+            echo "update_needed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          rm versions.yaml
+
+      - name: Update kubectl version
+        if: steps.version.outputs.update_needed == 'true'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          sed -i "/name: kubectl/{n;n;s/version: v[0-9]*\.[0-9]*\.[0-9]*/version: ${NEW_VERSION}/}" \
+            dockerfile-configs/common-components.yaml
+
+      - name: Create pull request
+        if: steps.version.outputs.update_needed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Update kubectl minor version to ${{ steps.version.outputs.new_version }}"
+          branch: chore/update-kubectl-minor
+          title: "Update kubectl minor version to ${{ steps.version.outputs.new_version }}"
+          body: |
+            Automated update of kubectl minor version.
+
+            The highest supported Kubernetes version in `gardener/gardener` is **1.${{ steps.version.outputs.highest_minor }}**.
+            Following the convention of `highest - 1`, the kubectl minor version is updated to **1.${{ steps.version.outputs.desired_minor }}**.
+
+            Previous version: `${{ steps.version.outputs.current_version }}`
+            New version: `${{ steps.version.outputs.new_version }}`
+
+            > Renovate will follow up with patch version updates.
+
+            **Release note**:
+            ```other dependency
+            `kubectl` minor version has been updated to `${{ steps.version.outputs.new_version }}` based on Kubernetes versions supported by `gardener/gardener`.
+            ```
+          labels: kind/enhancement

--- a/.github/workflows/update-kubectl-minor.yaml
+++ b/.github/workflows/update-kubectl-minor.yaml
@@ -23,7 +23,7 @@ jobs:
 
           # Find highest supported minor version, subtract 1
           HIGHEST_MINOR=$(yq '.versions[].version' versions.yaml | sort -V | tail -1 | cut -d. -f2)
-          DESIRED_MINOR=$((HIGHEST_MINOR - 0))
+          DESIRED_MINOR=$((HIGHEST_MINOR - 1))
 
           # Read current version from common-components.yaml
           CURRENT_VERSION=$(yq '.. | select(has("name")) | select(.name == "kubectl") | .version' dockerfile-configs/common-components.yaml)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
With this PR we get a pipeline that will pull the g/g version skew file and calculate the `kubectl` version from there.

**Which issue(s) this PR fixes**:
Fixes #259 

**Special notes for your reviewer**:
/invite @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`kubectl` is fully auto-managed now.
```
