### PR TITLE
Add validate tools functionality

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,6 +74,28 @@ jobs:
       ocm-labels: ${{ toJSON(matrix.args.ocm-labels) }}
       extra-tags: latest
 
+  validate-image:
+    name: Validate OCI-Image
+    needs:
+      - oci-images
+      - prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: validate-image
+        shell: bash
+        run: |
+          set -euo pipefail
+          BUILT_IMAGE="${{ needs.prepare.outputs.oci-registry }}/gardener/ops-toolbelt:${{ needs.prepare.outputs.version }}"
+          VALIDATION_IMAGE="${{ needs.prepare.outputs.oci-registry }}/gardener/ops-toolbelt-validation:${{ needs.prepare.outputs.version }}"
+          docker pull "${BUILT_IMAGE}"
+          make validate-image BUILT_IMAGE="${BUILT_IMAGE}"
+          docker tag "${BUILT_IMAGE}-validation" "${VALIDATION_IMAGE}"
+          docker push "${VALIDATION_IMAGE}"
+
   test:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,7 +83,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
+      - uses: gardener/cc-utils/.github/actions/install-gardener-gha-libs@master
+      - uses: gardener/cc-utils/.github/actions/oci-auth@master
+        with:
+          oci-image-reference: ${{ needs.prepare.outputs.oci-registry }}/gardener/ops-toolbelt-validation:${{ needs.prepare.outputs.version }}
+          gh-token: ${{ github.token }}
       - uses: actions/checkout@v6
       - name: validate-image
         shell: bash
@@ -92,8 +98,7 @@ jobs:
           BUILT_IMAGE="${{ needs.prepare.outputs.oci-registry }}/gardener/ops-toolbelt:${{ needs.prepare.outputs.version }}"
           VALIDATION_IMAGE="${{ needs.prepare.outputs.oci-registry }}/gardener/ops-toolbelt-validation:${{ needs.prepare.outputs.version }}"
           docker pull "${BUILT_IMAGE}"
-          make validate-image BUILT_IMAGE="${BUILT_IMAGE}"
-          docker tag "${BUILT_IMAGE}-validation" "${VALIDATION_IMAGE}"
+          make validate-image BUILT_IMAGE="${BUILT_IMAGE}" VALIDATION_IMAGE="${VALIDATION_IMAGE}"
           docker push "${VALIDATION_IMAGE}"
 
   test:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ APP = generator
 GARDENLINUX_IMAGE_TAG ?= 2150.1.0
 GARDENLINUX_IMAGE_REPO ?= ghcr.io/gardenlinux/gardenlinux
 BUILT_IMAGE ?= ops-toolbelt
-VALIDATION_DOCKERFILE ?= generated_dockerfiles/$(BUILT_IMAGE)-validation.dockerfile
+VALIDATION_IMAGE ?= $(BUILT_IMAGE)-validation
+VALIDATION_DOCKERFILE ?= generated_dockerfiles/ops-toolbelt-validation.dockerfile
 
 ifeq ($(shell uname), Darwin)
     OPEN = open
@@ -83,7 +84,7 @@ build-validation-dockerfile: ensure-venv ## Generate validation Dockerfile
 
 validate-image: build-validation-dockerfile ## Validate the built image by running all validation_commands
 	@echo Validating image $(BUILT_IMAGE)
-	@docker build -t $(BUILT_IMAGE)-validation -f $(VALIDATION_DOCKERFILE) . --no-cache
+	@docker build -t $(VALIDATION_IMAGE) -f $(VALIDATION_DOCKERFILE) . --no-cache
 
 ##@ Testing
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ APP = generator
 GARDENLINUX_IMAGE_TAG ?= 2150.1.0
 GARDENLINUX_IMAGE_REPO ?= ghcr.io/gardenlinux/gardenlinux
 BUILT_IMAGE ?= ops-toolbelt
+VALIDATION_DOCKERFILE ?= generated_dockerfiles/$(BUILT_IMAGE)-validation.dockerfile
 
 ifeq ($(shell uname), Darwin)
     OPEN = open
@@ -22,7 +23,7 @@ color_reset=\033[0m
 
 .DEFAULT_GOAL := help
 
-.PHONY: help ensure-venv ensure-shellcheck venv-build venv-update venv verify-bandit verify-shellcheck verify validate build build-image pkg-test pkg-test-with-report test reuse
+.PHONY: help ensure-venv ensure-shellcheck venv-build venv-update venv verify-bandit verify-shellcheck verify validate build build-image build-validation-dockerfile validate-image pkg-test pkg-test-with-report test reuse
 
 ##@ Help
 
@@ -72,6 +73,17 @@ build: ensure-venv ## Generate Dockerfile using the configured base image
 
 build-image: build ## Build the Docker image from the generated Dockerfile
 	@docker build -t $(BUILT_IMAGE) -f generated_dockerfiles/$(BUILT_IMAGE).dockerfile . --no-cache
+
+build-validation-dockerfile: ensure-venv ## Generate validation Dockerfile
+	@echo Generating validation dockerfile
+	@$(VENV_BIN)/generator-validation-dockerfile \
+		--from-image $(BUILT_IMAGE) \
+		--dockerfile-config dockerfile-configs/common-components.yaml \
+		--dockerfile $(VALIDATION_DOCKERFILE)
+
+validate-image: build-validation-dockerfile ## Validate the built image by running all validation_commands
+	@echo Validating image $(BUILT_IMAGE)
+	@docker build -t $(BUILT_IMAGE)-validation -f $(VALIDATION_DOCKERFILE) . --no-cache
 
 ##@ Testing
 

--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -54,9 +54,11 @@
     version: v1.3.5
     from: https://github.com/bronze1man/yaml2json/releases/download/{version}/yaml2json_linux_$(echo ${{TARGETARCH}} |sed 's/x86_64/amd64/;s/arm64/arm/')
     info: transform yaml string to json string without the type infomation.
+    validation_command: "echo '{}' | yaml2json"
   - name: kubetail
     from: https://raw.githubusercontent.com/johanhaleby/kubetail/master/kubetail
     info: Bash script that enables you to aggregate (tail/follow) logs from multiple pods into one stream
+    validation_command: "kubetail --help"
   - name: nerdctl
     # renovate: datasource=github-releases depName=containerd/nerdctl
     version: 2.2.2
@@ -69,11 +71,13 @@
       echo address = \"unix:///host/run/containerd/containerd.sock\" >> /etc/nerdctl/nerdctl.toml
       echo namespace = \"k8s.io\" >> /etc/nerdctl/nerdctl.toml
     info: nerdctl is a Docker-compatible CLI for containerd. The root directory of the host has to be mounted under `/host`
+    validation_command: "nerdctl --version"
   - name: kubectl
     # renovate: datasource=github-releases depName=kubernetes/kubernetes
     version: v1.34.6
     from: https://dl.k8s.io/release/{version}/bin/linux/${{TARGETARCH}}/kubectl
     info: command line tool for controlling Kubernetes clusters.
+    validation_command: "kubectl version --client"
 
 - name: bash
   items:

--- a/dockerfile-configs/common-components.yaml
+++ b/dockerfile-configs/common-components.yaml
@@ -15,37 +15,60 @@
 
 - name: apt-get
   items:
-  - curl
-  - tree
-  - vim-tiny
-  - htop
-  - less
-  - locales
-  - tmux
-  - bash-completion
-  - procps
-  - ngrep
-  - iotop
-  - iftop
-  - jq
-  - figlet
-  - tcpdump
-  - sysstat
-  - iputils-ping
-  - locales
-  - net-tools
+  - name: curl
+    validation_command: curl --version
+  - name: tree
+    validation_command: tree --version
+  - name: vim-tiny
+    validation_command: vi --version
+  - name: htop
+    validation_command: htop --version
+  - name: less
+    validation_command: less --version
+  - name: tmux
+    validation_command: tmux -V
+  - name: bash-completion
+    validation_command: dpkg -s bash-completion
+  - name: procps
+    validation_command: ps --version
+  - name: ngrep
+    validation_command: ngrep -V
+  - name: iotop
+    validation_command: iotop --version
+  - name: iftop
+    validation_command: iftop -h
+  - name: jq
+    validation_command: jq --version
+  - name: figlet
+    validation_command: figlet -v
+  - name: tcpdump
+    validation_command: tcpdump --version
+  - name: sysstat
+    validation_command: iostat
+  - name: iputils-ping
+    validation_command: ping -c 1 127.0.0.1
+  - name: locales
+    validation_command: locale --version
+  - name: net-tools
+    validation_command: netstat --version
   - name: silversearcher-ag
     provides: ag
+    validation_command: ag --version
   - name: iproute2
     provides: ip
+    validation_command: ip -V
   - name: dnsutils
     provides: ["delv", "dig", "mdig", "nslookup", "nsupdate"]
+    validation_command: dig -v
   - name: netcat-openbsd
     provides: netcat
+    validation_command: netcat -h
   - name: python3-minimal
     provides: python3
+    validation_command: python3 --version
   - name: python3-tabulate
     provides: tabulate
+    validation_command: python3 -c "import tabulate"
 
 - name: curl
   items:
@@ -125,21 +148,25 @@
     to: /nonroot/hacks
     command: --chown=65532:65532
     info: Bash script which installs the `k9s` tool in the container. If you are running this container as non-root, execute the `install_k9s` script in the `/nonroot/hacks` directory.
+    validation_command: k9s version
   - name: install_etcdctl
     from: ./hacks/install_etcdctl
     to: /nonroot/hacks
     command: --chown=65532:65532
     info: Bash script which installs the `etcdctl` tool in the container. If you are running this container as non-root, execute the `install_etcdctl` script in the `/nonroot/hacks` directory.
+    validation_command: etcdctl version
   - name: install_auger
     from: ./hacks/install_auger
     to: /nonroot/hacks
     command: --chown=65532:65532
     info: Bash script which installs the `auger` tool in the container. If you are running this container as non-root, execute the `install_auger` script in the `/nonroot/hacks` directory.
+    validation_command: auger version
   - name: install_pwru
     from: ./hacks/install_pwru
     to: /nonroot/hacks
     command: --chown=65532:65532
     info: Bash script which installs the `pwru` tool in the container. If you are running this container as non-root, execute the `install_pwru` script in the `/nonroot/hacks` directory.
+    validation_command: pwru --version
 
 - name: copy
   items:
@@ -148,6 +175,7 @@
     to: /nonroot/hacks/print-etcd-cheatsheet
     command: --chown=65532:65532
     info: Bash script which prints out etcd certificate paths and handy etcdctl comands. If you are running this container as a non-root container, execute the script in the `/nonroot/hacks` directory. Else use the one in `/hacks`. This script assumes an `etcd-backup-restore` process and an `etcd-wrapper` process are already running.
+    validation_command: bash -n /nonroot/hacks/print-etcd-cheatsheet
 
 - name: bash
   items:

--- a/hacks/install_k9s
+++ b/hacks/install_k9s
@@ -71,7 +71,7 @@ case "$1" in
     exit
     ;;
   *)
-    install ${@}
+    install "$@"
     exit
     ;;
 esac

--- a/hacks/install_k9s
+++ b/hacks/install_k9s
@@ -71,7 +71,7 @@ case "$1" in
     exit
     ;;
   *)
-    install
+    install ${@}
     exit
     ;;
 esac

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
 [project.scripts]
 generator = "generator.main:generate_dockerfile"
 generator-validate = "generator.main:validate"
+generator-validation-dockerfile = "generator.main:generate_validation_dockerfile"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/generator/main.py
+++ b/src/generator/main.py
@@ -89,7 +89,10 @@ def generate_validation_dockerfile():
 
     validation_commands = collect_validation_commands(dockerfile.components)
 
-    lines = [f"FROM {s.from_image}"]
+    lines = [
+        f"FROM {s.from_image}",
+        'SHELL ["/bin/bash", "-lic"]',
+    ]
     for name, cmd in validation_commands:
         lines.append(f"# Validate: {name}")
         lines.append(f"RUN {cmd}")

--- a/src/generator/main.py
+++ b/src/generator/main.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 from pydantic import FilePath, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from generator.models import Dockerfile, InfoGenerator
+from generator.models import BaseItem, Dockerfile, InfoGenerator
 from generator.utils import directives_to_layers
 
 
@@ -23,6 +23,11 @@ class ValidateSettings(BaseSettings):
 class GeneratorSettings(ValidateSettings):
     from_image: str = "ghcr.io/gardenlinux/gardenlinux:latest"
     title: str = "gardener shell"
+    dockerfile: Path
+
+
+class ValidationGeneratorSettings(ValidateSettings):
+    from_image: str = "ops-toolbelt"
     dockerfile: Path
 
 
@@ -58,3 +63,36 @@ def generate_dockerfile():
                 directives_to_layers(dockerfile.components)
             )
         )
+
+
+def collect_validation_commands(components: list) -> list[tuple[str, str]]:
+    """Walk all components and collect (name, validation_command) from items."""
+    result = []
+    for component in components:
+        if not hasattr(component, "items"):
+            continue
+        for item in component.items:
+            if isinstance(item, BaseItem) and item.validation_command:
+                result.append((item.name, item.validation_command))
+    return result
+
+
+def generate_validation_dockerfile():
+    s = ValidationGeneratorSettings()  # type: ignore
+    with open(s.dockerfile_config, encoding="utf-8") as f:
+        components = yaml.safe_load(f)
+    dockerfile = Dockerfile(
+        dockerfile_file=s.dockerfile,
+        components=components,
+        from_image=s.from_image,
+    )
+
+    validation_commands = collect_validation_commands(dockerfile.components)
+
+    lines = [f"FROM {s.from_image}"]
+    for name, cmd in validation_commands:
+        lines.append(f"# Validate: {name}")
+        lines.append(f"RUN {cmd}")
+
+    with open(s.dockerfile, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")

--- a/src/generator/models.py
+++ b/src/generator/models.py
@@ -74,6 +74,7 @@ class OpinionatedBaseModel(BaseModel):
 class BaseItem(OpinionatedBaseModel):
     name: PackageNameString
     info: InfoString = None
+    validation_command: str | None = None
 
     def dump_ghelp(self) -> tuple[PackageNameString, str | None, InfoString]:
         return self.name, getattr(self, 'version', None), self.info

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -187,6 +187,7 @@ def test_generate_validation_dockerfile(tmp_path, mocker):
     content = output_file.read_text()
     assert content == (
         "FROM my-image:latest\n"
+        'SHELL ["/bin/bash", "-lic"]\n'
         "# Validate: kubectl\n"
         "RUN kubectl version --client\n"
         "# Validate: setup\n"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,194 @@
+#! /usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from generator.main import collect_validation_commands
+from generator.models import (
+    AptGetItemList,
+    BashItemList,
+    CopyItemList,
+    CurlItemList,
+    Dockerfile,
+    EnvItemList,
+)
+
+
+def make_dockerfile(components: list) -> Dockerfile:
+    return Dockerfile(
+        dockerfile_file=Path("/dev/null"),
+        components=components,
+    )
+
+
+def test_collect_validation_commands_from_curl_items():
+    components = [
+        CurlItemList.model_validate({
+            "name": "curl",
+            "items": [
+                {
+                    "name": "kubectl",
+                    "from": "http://example.com/kubectl",
+                    "validation_command": "kubectl version --client",
+                },
+                {
+                    "name": "nerdctl",
+                    "from": "http://example.com/nerdctl",
+                },
+            ],
+        })
+    ]
+    df = make_dockerfile(components)
+    result = collect_validation_commands(df.components)
+    assert result == [("kubectl", "kubectl version --client")]
+
+
+def test_collect_validation_commands_from_bash_items():
+    components = [
+        BashItemList.model_validate({
+            "name": "bash",
+            "items": [
+                {
+                    "name": "locale",
+                    "command": "locale-gen",
+                    "validation_command": "locale -a | grep en_US",
+                },
+                {
+                    "name": "other",
+                    "command": "echo hi",
+                },
+            ],
+        })
+    ]
+    df = make_dockerfile(components)
+    result = collect_validation_commands(df.components)
+    assert result == [("locale", "locale -a | grep en_US")]
+
+
+def test_collect_validation_commands_from_apt_get_items():
+    components = [
+        AptGetItemList.model_validate({
+            "name": "apt-get",
+            "items": [
+                {"name": "jq", "validation_command": "jq --version"},
+                "curl",  # plain string, no validation_command
+                {"name": "vim-tiny"},
+            ],
+        })
+    ]
+    df = make_dockerfile(components)
+    result = collect_validation_commands(df.components)
+    assert result == [("jq", "jq --version")]
+
+
+def test_collect_validation_commands_skips_env_and_arg():
+    components = [
+        EnvItemList.model_validate({
+            "name": "env",
+            "items": ["KEY=val"],
+        })
+    ]
+    df = make_dockerfile(components)
+    result = collect_validation_commands(df.components)
+    assert result == []
+
+
+def test_collect_validation_commands_empty():
+    df = make_dockerfile([])
+    result = collect_validation_commands(df.components)
+    assert result == []
+
+
+def test_collect_validation_commands_mixed(mocker):
+    mocker.patch("pathlib.Path.is_file", return_value=True)
+    mocker.patch("pathlib.Path.is_dir", return_value=True)
+    mocker.patch("pathlib.Path.exists", return_value=True)
+
+    components = [
+        AptGetItemList.model_validate({
+            "name": "apt-get",
+            "items": [
+                {"name": "jq", "validation_command": "jq --version"},
+                "curl",
+            ],
+        }),
+        CurlItemList.model_validate({
+            "name": "curl",
+            "items": [
+                {
+                    "name": "kubectl",
+                    "from": "http://example.com/kubectl",
+                    "validation_command": "kubectl version --client",
+                },
+            ],
+        }),
+        BashItemList.model_validate({
+            "name": "bash",
+            "items": [{"name": "setup", "command": "echo hi"}],
+        }),
+        CopyItemList.model_validate({
+            "name": "copy",
+            "items": [
+                {
+                    "name": "scripts",
+                    "from": "/src",
+                    "to": "/dst",
+                    "validation_command": "test -d /dst",
+                },
+            ],
+        }),
+    ]
+    df = make_dockerfile(components)
+    result = collect_validation_commands(df.components)
+    assert result == [
+        ("jq", "jq --version"),
+        ("kubectl", "kubectl version --client"),
+        ("scripts", "test -d /dst"),
+    ]
+
+
+def test_generate_validation_dockerfile(tmp_path, mocker):
+    config_content = """
+- name: curl
+  items:
+  - name: kubectl
+    from: http://example.com/kubectl
+    validation_command: kubectl version --client
+  - name: tool
+    from: http://example.com/tool
+- name: bash
+  items:
+  - name: setup
+    command: echo hi
+    validation_command: echo ok
+"""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(config_content)
+    output_file = tmp_path / "Dockerfile.validation"
+
+    mocker.patch(
+        "generator.main.ValidationGeneratorSettings",
+        return_value=mocker.Mock(
+            dockerfile_config=config_file,
+            from_image="my-image:latest",
+            dockerfile=output_file,
+        ),
+    )
+
+    from generator.main import generate_validation_dockerfile
+
+    generate_validation_dockerfile()
+
+    content = output_file.read_text()
+    assert content == (
+        "FROM my-image:latest\n"
+        "# Validate: kubectl\n"
+        "RUN kubectl version --client\n"
+        "# Validate: setup\n"
+        "RUN echo ok\n"
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -643,6 +643,59 @@ def test_info_generator_to_ghelp_format_downloaded_only():
         ],
     }
     assert result == expected
+def test_validation_command_on_bash_item():
+    item = m.BashItem(name="test", command="echo hello", validation_command="echo hello")
+    assert item.validation_command == "echo hello"
+
+    item_none = m.BashItem(name="test", command="echo hello")
+    assert item_none.validation_command is None
+
+
+def test_validation_command_on_curl_item():
+    c = m.CurlItem.model_validate({
+        "name": "tool",
+        "from": "http://example.com/tool",
+        "validation_command": "tool --version",
+    })
+    assert c.validation_command == "tool --version"
+
+
+def test_validation_command_on_apt_get_item():
+    a = m.AptGetItem.model_validate({
+        "name": "jq",
+        "validation_command": "jq --version",
+    })
+    assert a.validation_command == "jq --version"
+    assert a.provides == "jq"
+
+
+def test_validation_command_on_copy_item(mocker):
+    mocker.patch("pathlib.Path.is_file", return_value=True)
+    mocker.patch("pathlib.Path.exists", return_value=True)
+    c = m.CopyItem.model_validate({
+        "name": "myfile",
+        "from": "/my/path",
+        "to": "/dest",
+        "validation_command": "test -f /dest",
+    })
+    assert c.validation_command == "test -f /dest"
+    assert c.to_dockerfile_directive() == "COPY /my/path /dest"
+
+
+def test_validation_command_does_not_affect_dump_ghelp():
+    item = m.BashItem(name="test", command="echo", info="info", validation_command="echo ok")
+    assert item.dump_ghelp() == ("test", None, "info")
+
+    curl = m.CurlItem.model_validate({
+        "name": "tool",
+        "version": "1.0",
+        "from": "http://example.com/tool",
+        "info": "Tool info",
+        "validation_command": "tool --version",
+    })
+    assert curl.dump_ghelp() == ("tool", "1.0", "Tool info")
+
+
 def test_info_multiline_string_validator():
     assert m.info_multiline_string_validator("single line") == "single line"
     string = "line1\nline2\nline3"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement
/area testing

**What this PR does / why we need it**:
Adds end-to-end validation for the ops-toolbelt container image.
A new `validation_command` field on item models allows each tool in the YAML config to declare a command that verifies it was installed correctly. The generator produces a separate validation Dockerfile that runs all validation commands.
The validation image is also pushed so we it can be validated against private clusters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
ops-toolbelt images are now validated end-to-end after build. Each tool declares a validation command that is executed in the built image to verify correct installation.
```
