### PR TITLE
Upgrading etcdctl to version 3.5.27

### DIFF
--- a/hacks/install_etcdctl
+++ b/hacks/install_etcdctl
@@ -12,7 +12,7 @@ function show_help () {
 }
 
 function install () {
-  etcd_version="v3.4.34"
+  etcd_version="v3.5.27"
   local version="${1:-${etcd_version}}"
   local download_url
   local arch
@@ -49,7 +49,7 @@ function install () {
     rm -rf "${tmp_dir}"
 
   echo -e "${yellow}"
-  echo "You can now start using etcdctl. Just execute \"etcdctl\" to use it. See https://etcd.io/docs/v3.4/dev-guide/interacting_v3/ for more details."
+  echo "You can now start using etcdctl. Just execute \"etcdctl\" to use it. See https://etcd.io/docs/v3.5/dev-guide/interacting_v3/ for more details."
   echo "This tool assumes that it is being run in an ephemeral container in a pod. If this is not the case, please ensure that you provide the correct certificates, the correct endpoint, and have all necessary accesses."
   echo "Certificates to be passed to the command should be mounted onto any container in the pod having a shared process namespace. Please run \"ps -A\" to list all processes and then access the certificates using \"/proc/<proc number>/root/<file-path>\". Pass these certificate file paths to the etcdctl command :)"
   echo -e "${nc}"


### PR DESCRIPTION
/area ops-productivity
/kind task

**What this PR does / why we need it**:
Etcd have been upgraded to `v3.5.27`: https://github.com/gardener/etcd-druid/issues/445, hence this PR upgrades the `etcdctl` to `v3.5.27`.

```
I have no name!@etcd-main-0:/$ etcdctl version
etcdctl version: 3.5.27
API version: 3.5
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shreyas-s14

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Upgrading etcdctl to use v3.5.27
```
